### PR TITLE
Only build master pushes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: java
 jdk:
   - oraclejdk8
 
+branches:
+  only:
+  - master
+  
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/


### PR DESCRIPTION
Since we still commit PRs as branches into this repo Travis will build every PR twice plus the merge commit. This means three equal builds for nothing. We should save their resources and (for now) just build the master branch. That way a PR will only be built once plus the actual merge on master to update the build status badge.
