### PR TITLE
Replace StreamSupport with com.annimon.stream (7k methods vs 600)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ checkstyleMain.doLast {
 
 dependencies {
     compile 'com.google.code.gson:gson:2.7'
-    compile 'net.sourceforge.streamsupport:streamsupport:1.5'
+    compile 'com.annimon:stream:1.1.1'
     compile 'com.squareup.okhttp3:okhttp:3.4.0-RC1'
     compile 'com.google.protobuf:protobuf-java:3.0.0-beta-3'
     compileOnly 'org.projectlombok:lombok:1.16.6'

--- a/src/main/java/com/pokegoapi/api/inventory/PokeBank.java
+++ b/src/main/java/com/pokegoapi/api/inventory/PokeBank.java
@@ -16,11 +16,11 @@
 package com.pokegoapi.api.inventory;
 
 import POGOProtos.Enums.PokemonIdOuterClass;
+import com.annimon.stream.Collectors;
+import com.annimon.stream.Stream;
+import com.annimon.stream.function.Predicate;
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.pokemon.Pokemon;
-import java8.util.function.Predicate;
-import java8.util.stream.Collectors;
-import java8.util.stream.StreamSupport;
 import lombok.Getter;
 
 import java.util.ArrayList;
@@ -43,7 +43,7 @@ public class PokeBank {
 	 */
 	public void addPokemon(final Pokemon pokemon) {
 		pokemon.setPgo(instance);
-		List<Pokemon> alreadyAdded = StreamSupport.stream(pokemons).filter(new Predicate<Pokemon>() {
+		List<Pokemon> alreadyAdded = Stream.of(pokemons).filter(new Predicate<Pokemon>() {
 			@Override
 			public boolean test(Pokemon testPokemon) {
 				return pokemon.getId() == testPokemon.getId();
@@ -63,7 +63,7 @@ public class PokeBank {
 	 * @return the pokemon by pokemon id
 	 */
 	public List<Pokemon> getPokemonByPokemonId(final PokemonIdOuterClass.PokemonId id) {
-		return StreamSupport.stream(pokemons).filter(new Predicate<Pokemon>() {
+		return Stream.of(pokemons).filter(new Predicate<Pokemon>() {
 			@Override
 			public boolean test(Pokemon pokemon) {
 				return pokemon.getPokemonId().equals(id);
@@ -77,7 +77,7 @@ public class PokeBank {
 	 * @param pokemon the pokemon
 	 */
 	public void removePokemon(final Pokemon pokemon) {
-		pokemons = StreamSupport.stream(pokemons).filter(new Predicate<Pokemon>() {
+		pokemons = Stream.of(pokemons).filter(new Predicate<Pokemon>() {
 			@Override
 			public boolean test(Pokemon pokemn) {
 				return pokemn.getId() != pokemon.getId();

--- a/src/main/java/com/pokegoapi/api/map/Map.java
+++ b/src/main/java/com/pokegoapi/api/map/Map.java
@@ -35,6 +35,9 @@ import POGOProtos.Networking.Responses.EncounterResponseOuterClass.EncounterResp
 import POGOProtos.Networking.Responses.FortDetailsResponseOuterClass;
 import POGOProtos.Networking.Responses.FortSearchResponseOuterClass.FortSearchResponse;
 import POGOProtos.Networking.Responses.GetMapObjectsResponseOuterClass;
+import com.annimon.stream.Collectors;
+import com.annimon.stream.Stream;
+import com.annimon.stream.function.Function;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.map.fort.FortDetails;
@@ -46,9 +49,6 @@ import com.pokegoapi.google.common.geometry.MutableInteger;
 import com.pokegoapi.google.common.geometry.S2CellId;
 import com.pokegoapi.google.common.geometry.S2LatLng;
 import com.pokegoapi.main.ServerRequest;
-import java8.util.function.Function;
-import java8.util.stream.Collectors;
-import java8.util.stream.StreamSupport;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -291,7 +291,9 @@ public class Map {
 			result.addDecimatedSpawnPoints(mapCell.getDecimatedSpawnPointsList());
 			result.addSpawnPoints(mapCell.getSpawnPointsList());
 
-			java.util.Map<FortType, List<FortData>> groupedForts = StreamSupport.stream(mapCell.getFortsList())
+
+
+			java.util.Map<FortType, List<FortData>> groupedForts = Stream.of(mapCell.getFortsList())
 					.collect(Collectors.groupingBy(new Function<FortData, FortType>() {
 						@Override
 						public FortType apply(FortData fortData) {


### PR DESCRIPTION
There's no reason to use StreamSupport (a massive library) for a couple of utility methods when there are more lightweight alternatives. This is also very important for android devs. This pr replaces [StreamSupport](https://github.com/streamsupport/streamsupport) with [com.annimon.stream](https://github.com/aNNiMON/Lightweight-Stream-API).
