### PR TITLE
ChatchResult.isFailed should only concern response issue or status.

### DIFF
--- a/src/main/java/com/pokegoapi/api/map/pokemon/CatchResult.java
+++ b/src/main/java/com/pokegoapi/api/map/pokemon/CatchResult.java
@@ -43,7 +43,7 @@ public class CatchResult {
 
 	public CatchStatus getStatus() {
 		return response.getStatus();
-	}
+	}  
 
 	public double getMissPercent() {
 		return response.getMissPercent();
@@ -75,9 +75,6 @@ public class CatchResult {
 	 * @return the boolean
 	 */
 	public boolean isFailed() {
-		if (response == null) {
-			return failed;
-		}
-		return (this.getStatus() != CatchStatus.CATCH_SUCCESS || failed);
+		return (response == null);
 	}
 }

--- a/src/main/java/com/pokegoapi/api/map/pokemon/CatchResult.java
+++ b/src/main/java/com/pokegoapi/api/map/pokemon/CatchResult.java
@@ -43,7 +43,7 @@ public class CatchResult {
 
 	public CatchStatus getStatus() {
 		return response.getStatus();
-	}  
+	}
 
 	public double getMissPercent() {
 		return response.getMissPercent();


### PR DESCRIPTION
In the previous version, isFailed can return true if response == null or if gestStatus() != CatchStatus.CATCH_SUCCESS.

It is a problem because the user may want to check why it failed, maybe it is because the inventory is full or because of a soft ban. To check this, the user will call getStatus(), but getStatus will throw a null reference exception if response == null.

I suggest that isFailed should only return true if response == null and the user handle the status value on his side.
