### PR TITLE
Level enum public for custom loggers

### DIFF
--- a/src/main/java/com/pokegoapi/util/Log.java
+++ b/src/main/java/com/pokegoapi/util/Log.java
@@ -95,7 +95,7 @@ public class Log {
 		getInstance().wtf(tag, msg, tr);
 	}
 
-	enum Level {
+	public enum Level {
 
 		VERBOSE(2),
 		DEBUG(3),


### PR DESCRIPTION
**Changes made:** Enum level in class Log is now public

Reason for change: we can now create custom loggers that extend BaseLogger.
