### PR TITLE
add license to GoogleLoginSecrets

### DIFF
--- a/src/main/java/com/pokegoapi/auth/GoogleLoginSecrets.java
+++ b/src/main/java/com/pokegoapi/auth/GoogleLoginSecrets.java
@@ -1,8 +1,19 @@
-package com.pokegoapi.auth;
-
-/**
- * Created by RajulB on 7/23/2016.
+/*
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+package com.pokegoapi.auth;
 
 public class GoogleLoginSecrets {
 	public static final String SECRET = "NCjF1TLi2CcY6t5mt0ZveuL7";


### PR DESCRIPTION
**Changes made:**
- add missing license to file because https://github.com/Grover-c13/PokeGOAPI-Java/pull/165#discussion_r71978495 was ignored :/
