### PR TITLE
Runtimeexceptions

### DIFF
--- a/src/main/java/com/pokegoapi/exceptions/InvalidCurrencyException.java
+++ b/src/main/java/com/pokegoapi/exceptions/InvalidCurrencyException.java
@@ -15,7 +15,7 @@
 
 package com.pokegoapi.exceptions;
 
-public class InvalidCurrencyException extends Exception {
+public class InvalidCurrencyException extends PokemonGoApiException {
 	public InvalidCurrencyException() {
 		super();
 	}

--- a/src/main/java/com/pokegoapi/exceptions/LoginFailedException.java
+++ b/src/main/java/com/pokegoapi/exceptions/LoginFailedException.java
@@ -15,7 +15,7 @@
 
 package com.pokegoapi.exceptions;
 
-public class LoginFailedException extends Exception {
+public class LoginFailedException extends PokemonGoApiException {
 	public LoginFailedException() {
 		super();
 	}

--- a/src/main/java/com/pokegoapi/exceptions/NoSuchItemException.java
+++ b/src/main/java/com/pokegoapi/exceptions/NoSuchItemException.java
@@ -15,7 +15,7 @@
 
 package com.pokegoapi.exceptions;
 
-public class NoSuchItemException extends Exception {
+public class NoSuchItemException extends PokemonGoApiException {
 	public NoSuchItemException() {
 		super();
 	}

--- a/src/main/java/com/pokegoapi/exceptions/PokemonGoApiException.java
+++ b/src/main/java/com/pokegoapi/exceptions/PokemonGoApiException.java
@@ -1,0 +1,14 @@
+package com.pokegoapi.exceptions;
+
+public class PokemonGoApiException extends RuntimeException {
+	public PokemonGoApiException() {
+	}
+
+	public PokemonGoApiException(String message) {
+		super(message);
+	}
+
+	public PokemonGoApiException(Throwable cause) {
+		super(cause);
+	}
+}

--- a/src/main/java/com/pokegoapi/exceptions/RemoteServerException.java
+++ b/src/main/java/com/pokegoapi/exceptions/RemoteServerException.java
@@ -15,7 +15,7 @@
 
 package com.pokegoapi.exceptions;
 
-public class RemoteServerException extends Exception {
+public class RemoteServerException extends PokemonGoApiException {
 	public RemoteServerException() {
 		super();
 	}


### PR DESCRIPTION
I've changed the default Exception to a specific PokemonGoApiException which itself extends RuntimeException instead of Exception. 

This allows for easier exception checking and makes the API usable in the Java8 stream API. 

Change is backwards compatible with existing code and API implementations. 
