### PR TITLE
Use gradle-wrapper instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ ___
 # Build
   - Clone the repo and cd into the folder
   - `` git submodule update --init ``
-  - verify that you have gradle in your path
-  - `` gradle build bundle ``
+  - compile and package
+  - `` ./gradlew build bundle ``
   - you should have the api bundled in ``build/libs/PokeGOAPI-Java_bundle-0.0.1-SNAPSHOT.jar``
 
   PS : To Eclipse user, you must build once : `` gradle build `` and add the generated java class for proto into eclipse source path : Right click on the project > Build path > Configure Build Path > Source > Add Folder > Select `build/generated/source/proto/main/java` > Finish

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ___
   - `` ./gradlew build bundle ``
   - you should have the api bundled in ``build/libs/PokeGOAPI-Java_bundle-0.0.1-SNAPSHOT.jar``
 
-  PS : To Eclipse user, you must build once : `` gradle build `` and add the generated java class for proto into eclipse source path : Right click on the project > Build path > Configure Build Path > Source > Add Folder > Select `build/generated/source/proto/main/java` > Finish
+  PS : To Eclipse user, you must build once : `` ./gradlew build `` and add the generated java class for proto into eclipse source path : Right click on the project > Build path > Configure Build Path > Source > Add Folder > Select `build/generated/source/proto/main/java` > Finish
 
 # Usage
 Include the API as jar from your own build, or use Maven/Gradle/SBT/Leiningen: https://jitpack.io/#Grover-c13/PokeGOAPI-Java/master-SNAPSHOT


### PR DESCRIPTION
Encourage people to use the gradle wrapper instead of their own version in order to make sure everyone uses the same version
