### PR TITLE
Added request to add modifiers to forts, for example a lure-module on a pokestop

### DIFF
--- a/src/main/java/com/pokegoapi/api/map/fort/Pokestop.java
+++ b/src/main/java/com/pokegoapi/api/map/fort/Pokestop.java
@@ -15,10 +15,13 @@
 
 package com.pokegoapi.api.map.fort;
 
+import POGOProtos.Inventory.Item.ItemIdOuterClass;
 import POGOProtos.Map.Fort.FortDataOuterClass;
+import POGOProtos.Networking.Requests.Messages.AddFortModifierMessageOuterClass.AddFortModifierMessage;
 import POGOProtos.Networking.Requests.Messages.FortDetailsMessageOuterClass.FortDetailsMessage;
 import POGOProtos.Networking.Requests.Messages.FortSearchMessageOuterClass.FortSearchMessage;
 import POGOProtos.Networking.Requests.RequestTypeOuterClass;
+import POGOProtos.Networking.Responses.AddFortModifierResponseOuterClass;
 import POGOProtos.Networking.Responses.FortDetailsResponseOuterClass;
 import POGOProtos.Networking.Responses.FortSearchResponseOuterClass;
 import com.google.protobuf.InvalidProtocolBufferException;
@@ -124,6 +127,29 @@ public class Pokestop {
 		}
 		cooldownCompleteTimestampMs = response.getCooldownCompleteTimestampMs();
 		return new PokestopLootResult(response);
+	}
+
+	/**
+	 * Adds a modifier to this pokestop. (i.e. add a lure module)
+	 *
+	 * @param item the modifier to add to this pokestop
+	 */
+	public void addModifier(ItemIdOuterClass.ItemId item) throws LoginFailedException, RemoteServerException {
+		AddFortModifierMessage msg = AddFortModifierMessage.newBuilder()
+				.setModifierType(item)
+				.setFortId(getId())
+				.setPlayerLatitude(api.getLatitude())
+				.setPlayerLongitude(api.getLongitude())
+				.build();
+		ServerRequest serverRequest = new ServerRequest(RequestTypeOuterClass.RequestType.ADD_FORT_MODIFIER, msg);
+		api.getRequestHandler().sendServerRequests(serverRequest);
+		AddFortModifierResponseOuterClass.AddFortModifierResponse response;
+		try {
+			//sadly the server response does not contain any information to verify if the request was successful
+			response = AddFortModifierResponseOuterClass.AddFortModifierResponse.parseFrom(serverRequest.getData());
+		} catch (InvalidProtocolBufferException e) {
+			throw new RemoteServerException(e);
+		}
 	}
 
 	/**

--- a/src/main/java/com/pokegoapi/api/map/fort/Pokestop.java
+++ b/src/main/java/com/pokegoapi/api/map/fort/Pokestop.java
@@ -133,6 +133,8 @@ public class Pokestop {
 	 * Adds a modifier to this pokestop. (i.e. add a lure module)
 	 *
 	 * @param item the modifier to add to this pokestop
+	 * @throws LoginFailedException if login failed
+	 * @throws RemoteServerException if the server failed to respond or the modifier could not be added to this pokestop
 	 */
 	public void addModifier(ItemIdOuterClass.ItemId item) throws LoginFailedException, RemoteServerException {
 		AddFortModifierMessage msg = AddFortModifierMessage.newBuilder()


### PR DESCRIPTION
**Changes made:**

Added a method `addModifier(ItemId)` to the `Pokestop` class which instantiates and sends a `AddFortModifierMessage` to the server. It is used to add the modifier specified as an ItemId to the pokestop, usually this modifier will be a lure module (`ITEM_TROY_DISK`).
