### PR TITLE
Add cause to LoginFailedExceptions.

### DIFF
--- a/src/main/java/com/pokegoapi/auth/GoogleLogin.java
+++ b/src/main/java/com/pokegoapi/auth/GoogleLogin.java
@@ -157,7 +157,7 @@ public class GoogleLogin extends Login {
 
 			return authbuilder.build();
 		} catch (Exception e) {
-			throw new LoginFailedException();
+			throw new LoginFailedException(e);
 		}
 
 	}

--- a/src/main/java/com/pokegoapi/auth/PtcLogin.java
+++ b/src/main/java/com/pokegoapi/auth/PtcLogin.java
@@ -193,7 +193,7 @@ public class PtcLogin extends Login {
 
 			return authbuilder.build();
 		} catch (Exception e) {
-			throw new LoginFailedException();
+			throw new LoginFailedException(e);
 		}
 
 	}


### PR DESCRIPTION
**Changes made:**
- This pr adds the cause of a failed login to the LoginFailedException as the cause. This is done for make debugging failed logins easier.
- Implemented for both login types: PTC and Google

Signed-off-by: Niklas Walter walter.niklas@gmail.com
