### PR TITLE
Remove printStackTrace from updateProfile

### DIFF
--- a/src/main/java/com/pokegoapi/api/player/PlayerProfile.java
+++ b/src/main/java/com/pokegoapi/api/player/PlayerProfile.java
@@ -82,7 +82,7 @@ public class PlayerProfile {
 		try {
 			playerResponse = GetPlayerResponseOuterClass.GetPlayerResponse.parseFrom(getPlayerServerRequest.getData());
 		} catch (InvalidProtocolBufferException e) {
-			e.printStackTrace();
+			throw new RemoteServerException(e);
 		}
 
 		badge = playerResponse.getPlayerData().getEquippedBadge();


### PR DESCRIPTION
**Old behavior:**

updateProfile, in case of failure, would dump stacktraces to the console and then crash in the next line with a NullPointerException

**Changes made:**
- Remove `e.printStackTrace`
- Add a `throw new RemoteServerException(e);` as is done everywhere else where the server might return garbage
