### PR TITLE
Deprecate pokemon.getFavorite, rename to pokemon.isFavorite

### DIFF
--- a/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
+++ b/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
@@ -341,7 +341,7 @@ public class Pokemon {
 	 * Checks whether the Pokémon is set as favorite.
 	 * @return true if the Pokémon is set as favorite
 	 */
-	public boolean isFavorite(){
+	public boolean isFavorite() {
 		return proto.getFavorite() > 0;
 	}
 

--- a/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
+++ b/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
@@ -336,7 +336,16 @@ public class Pokemon {
 	public long getCreationTimeMs() {
 		return proto.getCreationTimeMs();
 	}
+	
+	/**
+	 * Checks whether the Pokémon is set as favorite.
+	 * @return true if the Pokémon is set as favorite
+	 */
+	public boolean isFavorite(){
+		return proto.getFavorite() > 0;
+	}
 
+	@Deprecated
 	public boolean getFavorite() {
 		return proto.getFavorite() > 0;
 	}


### PR DESCRIPTION
**Changes** 
Deprecated `pokemon.getFavorite()
`Created `pokemon.isFavorite()`

As described in #219
