### PR TITLE
Consistently use RemoteServerException for network/server errors

### DIFF
--- a/src/main/java/com/pokegoapi/api/PokemonGo.java
+++ b/src/main/java/com/pokegoapi/api/PokemonGo.java
@@ -16,7 +16,6 @@
 package com.pokegoapi.api;
 
 import POGOProtos.Networking.Envelopes.RequestEnvelopeOuterClass;
-
 import com.pokegoapi.api.inventory.Inventories;
 import com.pokegoapi.api.map.Map;
 import com.pokegoapi.api.player.PlayerProfile;
@@ -25,7 +24,6 @@ import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.main.RequestHandler;
 import com.pokegoapi.util.Log;
-
 import lombok.Getter;
 import lombok.Setter;
 import okhttp3.OkHttpClient;
@@ -86,10 +84,12 @@ public class PokemonGo {
 
 	/**
 	 * Fetches valid AuthInfo
+	 *
 	 * @return AuthInfo object
 	 * @throws LoginFailedException when login fails
 	 */
-	public RequestEnvelopeOuterClass.RequestEnvelope.AuthInfo getAuthInfo() throws LoginFailedException {
+	public RequestEnvelopeOuterClass.RequestEnvelope.AuthInfo getAuthInfo()
+			throws LoginFailedException, RemoteServerException {
 		return credentialProvider.getAuthInfo();
 	}
 

--- a/src/main/java/com/pokegoapi/auth/CredentialProvider.java
+++ b/src/main/java/com/pokegoapi/auth/CredentialProvider.java
@@ -18,15 +18,16 @@ package com.pokegoapi.auth;
 import POGOProtos.Networking.Envelopes.RequestEnvelopeOuterClass.RequestEnvelope.AuthInfo;
 
 import com.pokegoapi.exceptions.LoginFailedException;
+import com.pokegoapi.exceptions.RemoteServerException;
 
 /**
  * Any Credential Provider can extend this.
  */
 public abstract class CredentialProvider {
 
-	public abstract String getTokenId() throws LoginFailedException;
+	public abstract String getTokenId() throws LoginFailedException, RemoteServerException;
 
-	public abstract AuthInfo getAuthInfo() throws LoginFailedException;
+	public abstract AuthInfo getAuthInfo() throws LoginFailedException, RemoteServerException;
 
 	public abstract boolean isTokenIdExpired();
 }

--- a/src/main/java/com/pokegoapi/exceptions/LoginFailedException.java
+++ b/src/main/java/com/pokegoapi/exceptions/LoginFailedException.java
@@ -29,6 +29,6 @@ public class LoginFailedException extends Exception {
 	}
 
 	public LoginFailedException(String reason, Exception exception) {
-		super(reason,exception);
+		super(reason, exception);
 	}
 }

--- a/src/main/java/com/pokegoapi/exceptions/RemoteServerException.java
+++ b/src/main/java/com/pokegoapi/exceptions/RemoteServerException.java
@@ -27,4 +27,8 @@ public class RemoteServerException extends Exception {
 	public RemoteServerException(Exception exception) {
 		super(exception);
 	}
+
+	public RemoteServerException(String reason, Exception exception) {
+		super(reason, exception);
+	}
 }

--- a/src/main/java/com/pokegoapi/main/RequestHandler.java
+++ b/src/main/java/com/pokegoapi/main/RequestHandler.java
@@ -17,16 +17,12 @@ package com.pokegoapi.main;
 
 import POGOProtos.Networking.Envelopes.AuthTicketOuterClass;
 import POGOProtos.Networking.Envelopes.RequestEnvelopeOuterClass;
-import POGOProtos.Networking.Envelopes.RequestEnvelopeOuterClass.RequestEnvelope.AuthInfo;
 import POGOProtos.Networking.Envelopes.ResponseEnvelopeOuterClass;
-
 import com.google.protobuf.ByteString;
 import com.pokegoapi.api.PokemonGo;
-import com.pokegoapi.auth.GoogleCredentialProvider;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.Log;
-
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 import okhttp3.Response;
@@ -54,7 +50,7 @@ public class RequestHandler {
 	 * @param api    the api
 	 * @param client the client
 	 */
-	public RequestHandler(PokemonGo api, OkHttpClient client) throws LoginFailedException {
+	public RequestHandler(PokemonGo api, OkHttpClient client) throws LoginFailedException, RemoteServerException {
 		this.api = api;
 		this.client = client;
 		apiEndpoint = ApiSettings.API_ENDPOINT;
@@ -178,7 +174,7 @@ public class RequestHandler {
 		try {
 			request.writeTo(stream);
 		} catch (IOException e) {
-			Log.wtf(TAG, "Failed to write request to bytearray ouput stream. This should never happen", e);
+			Log.wtf(TAG, "Failed to write request to bytearray output stream. This should never happen", e);
 		}
 
 		RequestBody body = RequestBody.create(null, stream.toByteArray());
@@ -194,7 +190,7 @@ public class RequestHandler {
 		}
 
 		if (response.code() != 200) {
-			throw new RemoteServerException("Got a unexcepted http code : " + response.code());
+			throw new RemoteServerException("Got a unexpected http code : " + response.code());
 		}
 
 		ResponseEnvelopeOuterClass.ResponseEnvelope responseEnvelop = null;
@@ -237,14 +233,15 @@ public class RequestHandler {
 	}
 
 	@Deprecated
-	private void resetBuilder() throws LoginFailedException {
+	private void resetBuilder() throws LoginFailedException, RemoteServerException {
 		builder = RequestEnvelopeOuterClass.RequestEnvelope.newBuilder();
 		resetBuilder(builder);
 		hasRequests = false;
 		serverRequests.clear();
 	}
 
-	private void resetBuilder(RequestEnvelopeOuterClass.RequestEnvelope.Builder builder) throws LoginFailedException {
+	private void resetBuilder(RequestEnvelopeOuterClass.RequestEnvelope.Builder builder)
+			throws LoginFailedException, RemoteServerException {
 		builder.setStatusCode(2);
 		builder.setRequestId(8145806132888207460L);
 		if (lastAuth != null


### PR DESCRIPTION
**Changes made:**
- Instead of always returning a LoginFailedException return a RemoteServerException when a network or server error occurs (makes wrong credentials distinguishable from broken network)
- Fix some typos
