### PR TITLE
Implemented request to accept level up rewards and unlocks

### DIFF
--- a/src/main/java/com/pokegoapi/api/player/PlayerLevelUpRewards.java
+++ b/src/main/java/com/pokegoapi/api/player/PlayerLevelUpRewards.java
@@ -1,0 +1,53 @@
+package com.pokegoapi.api.player;
+
+import POGOProtos.Inventory.Item.ItemAwardOuterClass;
+import POGOProtos.Inventory.Item.ItemIdOuterClass;
+import POGOProtos.Networking.Responses.LevelUpRewardsResponseOuterClass.LevelUpRewardsResponse;
+import lombok.Data;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A data class containing the results of a trainer level up. This includes a list of items received for this level up,
+ * a list of items which were unlocked by this level up (for example razz berries)
+ * and the status of these level up results.
+ * If the rewards for this level up have been
+ * accepted in the past the status will be ALREADY_ACCEPTED, if this level up has not yet been achieved
+ * by the player it will be NOT_UNLOCKED_YET otherwise it will be NEW.
+ *
+ * @author Alex Schlosser
+ */
+@Data
+public class PlayerLevelUpRewards {
+	private final Status status;
+	private final List<ItemAwardOuterClass.ItemAward> rewards;
+	private final List<ItemIdOuterClass.ItemId> unlockedItems;
+
+
+	/**
+	 * Create new empty result object with the specified status.
+	 *
+	 * @param status the status of this result
+	 */
+	public PlayerLevelUpRewards(final Status status) {
+		this.status = status;
+		this.rewards = Collections.emptyList();
+		this.unlockedItems = Collections.emptyList();
+	}
+
+	public enum Status {
+		ALREADY_ACCEPTED, NEW, NOT_UNLOCKED_YET
+	}
+
+	/**
+	 * Create a new result object based on a server response
+	 *
+	 * @param response the response which contains the request results
+	 */
+	public PlayerLevelUpRewards(final LevelUpRewardsResponse response) {
+		this.rewards = response.getItemsAwardedList();
+		this.unlockedItems = response.getItemsUnlockedList();
+		this.status = (rewards.isEmpty() ? Status.ALREADY_ACCEPTED : Status.NEW);
+	}
+}

--- a/src/main/java/com/pokegoapi/api/player/PlayerProfile.java
+++ b/src/main/java/com/pokegoapi/api/player/PlayerProfile.java
@@ -18,11 +18,18 @@ package com.pokegoapi.api.player;
 import POGOProtos.Data.Player.CurrencyOuterClass;
 import POGOProtos.Data.Player.EquippedBadgeOuterClass;
 import POGOProtos.Data.Player.PlayerStatsOuterClass;
+import POGOProtos.Inventory.Item.ItemAwardOuterClass;
 import POGOProtos.Networking.Requests.Messages.GetPlayerMessageOuterClass.GetPlayerMessage;
+import POGOProtos.Networking.Requests.Messages.LevelUpRewardsMessageOuterClass;
+import POGOProtos.Networking.Requests.Messages.LevelUpRewardsMessageOuterClass.LevelUpRewardsMessage;
+import POGOProtos.Networking.Requests.RequestTypeOuterClass;
 import POGOProtos.Networking.Requests.RequestTypeOuterClass.RequestType;
 import POGOProtos.Networking.Responses.GetPlayerResponseOuterClass;
+import POGOProtos.Networking.Responses.LevelUpRewardsResponseOuterClass;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.pokegoapi.api.PokemonGo;
+import com.pokegoapi.api.inventory.Item;
+import com.pokegoapi.api.inventory.ItemBag;
 import com.pokegoapi.exceptions.InvalidCurrencyException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
@@ -126,6 +133,43 @@ public class PlayerProfile {
 		dailyBonus = bonusApi;
 
 
+	}
+
+	/**
+	 * Accept the rewards granted and the items unlocked by gaining a trainer level up. Rewards are retained by the
+	 * server until a player actively accepts them.
+	 * The rewarded items are automatically inserted into the players item bag.
+	 *
+	 * @see PlayerLevelUpRewards
+	 * @param level the trainer level that you want to accept the rewards for
+	 * @return a PlayerLevelUpRewards object containing information about the items rewarded and unlocked for this level
+	 * @throws LoginFailedException  if the login failed
+	 * @throws RemoteServerException if the server failed to respond
+	 */
+	public PlayerLevelUpRewards acceptLevelUpRewards(int level) throws RemoteServerException, LoginFailedException {
+		// Check if we even have achieved this level yet
+		if (level > stats.getLevel()) {
+			return new PlayerLevelUpRewards(PlayerLevelUpRewards.Status.NOT_UNLOCKED_YET);
+		}
+		LevelUpRewardsMessage msg = LevelUpRewardsMessage.newBuilder()
+				.setLevel(level)
+				.build();
+		ServerRequest serverRequest = new ServerRequest(RequestTypeOuterClass.RequestType.LEVEL_UP_REWARDS, msg);
+		api.getRequestHandler().sendServerRequests(serverRequest);
+		LevelUpRewardsResponseOuterClass.LevelUpRewardsResponse response;
+		try {
+			response = LevelUpRewardsResponseOuterClass.LevelUpRewardsResponse.parseFrom(serverRequest.getData());
+		} catch (InvalidProtocolBufferException e) {
+			throw new RemoteServerException(e);
+		}
+		// Add the awarded items to our bag
+		ItemBag bag = api.getInventories().getItemBag();
+		for (ItemAwardOuterClass.ItemAward itemAward : response.getItemsAwardedList()) {
+			Item item = bag.getItem(itemAward.getItemId());
+			item.setCount(item.getCount() + itemAward.getItemCount());
+		}
+		// Build a new rewards object and return it
+		return new PlayerLevelUpRewards(response);
 	}
 
 	/**


### PR DESCRIPTION
**Partially fixed issue:** #188

**Changes made:**
- Added a method to `PlayerProfile` class to accept level up rewards and add the rewarded items to the players item bag.
- Added the data class `PlayerLevelUpRewards` which encapsulates the items rewarded for a level up, the items unlocked by a level up and information if the level has been accepted before or if it is not unlocked yet.
