### PR TITLE
Added new oauth for google user interaction to supercede GoogleCredentialProvider (example included) added a new hasLure method to Pokestops that is more reliable. Undeprecrated constructors that construct time objects by default

### DIFF
--- a/src/main/java/com/pokegoapi/api/PokemonGo.java
+++ b/src/main/java/com/pokegoapi/api/PokemonGo.java
@@ -102,7 +102,6 @@ public class PokemonGo {
 	 * @throws LoginFailedException  When login fails
 	 * @throws RemoteServerException When server fails
 	 */
-	@Deprecated
 	public PokemonGo(CredentialProvider credentialProvider, OkHttpClient client)
 			throws LoginFailedException, RemoteServerException {
 		this(credentialProvider, client, new SystemTimeImpl());

--- a/src/main/java/com/pokegoapi/api/map/fort/Pokestop.java
+++ b/src/main/java/com/pokegoapi/api/map/fort/Pokestop.java
@@ -17,6 +17,7 @@ package com.pokegoapi.api.map.fort;
 
 import POGOProtos.Inventory.Item.ItemIdOuterClass;
 import POGOProtos.Map.Fort.FortDataOuterClass;
+import POGOProtos.Map.Fort.FortModifierOuterClass;
 import POGOProtos.Networking.Requests.Messages.AddFortModifierMessageOuterClass.AddFortModifierMessage;
 import POGOProtos.Networking.Requests.Messages.FortDetailsMessageOuterClass.FortDetailsMessage;
 import POGOProtos.Networking.Requests.Messages.FortSearchMessageOuterClass.FortSearchMessage;
@@ -31,6 +32,8 @@ import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.google.common.geometry.S2LatLng;
 import com.pokegoapi.main.ServerRequest;
 import lombok.Getter;
+
+import java.util.List;
 
 /**
  * Created by mjmfighter on 7/20/2016.
@@ -183,7 +186,25 @@ public class Pokestop {
 	 * Returns whether this pokestop has an active lure.
 	 * @return lure status
 	 */
+	@Deprecated
 	public boolean hasLurePokemon() {
 		return fortData.hasLureInfo() && fortData.getLureInfo().getLureExpiresTimestampMs() < api.currentTimeMillis();
+	}
+
+	/**
+	 * Returns whether this pokestop has an active lure.
+	 * @return lure status
+	 */
+	public boolean hasLure() throws LoginFailedException, RemoteServerException {
+
+
+		List<FortModifierOuterClass.FortModifier> modifiers = getDetails().getModifier();
+		for (FortModifierOuterClass.FortModifier mod : modifiers) {
+			if (mod.getItemId() == ItemIdOuterClass.ItemId.ITEM_TROY_DISK) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/src/main/java/com/pokegoapi/auth/GoogleAutoCredentialProvider.java
+++ b/src/main/java/com/pokegoapi/auth/GoogleAutoCredentialProvider.java
@@ -36,7 +36,6 @@ public class GoogleAutoCredentialProvider extends CredentialProvider {
 	 * @throws LoginFailedException  - login failed possibly due to invalid credentials
 	 * @throws RemoteServerException - some server/network failure
 	 */
-	@Deprecated
 	public GoogleAutoCredentialProvider(OkHttpClient httpClient, String username, String password)
 			throws LoginFailedException, RemoteServerException {
 		this.gpsoauth = new Gpsoauth(httpClient);

--- a/src/main/java/com/pokegoapi/auth/PtcCredentialProvider.java
+++ b/src/main/java/com/pokegoapi/auth/PtcCredentialProvider.java
@@ -116,7 +116,6 @@ public class PtcCredentialProvider extends CredentialProvider {
 	 * @param username Username
 	 * @param password password
 	 */
-	@Deprecated
 	public PtcCredentialProvider(OkHttpClient client, String username, String password)
 			throws LoginFailedException, RemoteServerException {
 		this(client, username, password, new SystemTimeImpl());

--- a/src/main/java/com/pokegoapi/examples/GoogleUserInteractionExample.java
+++ b/src/main/java/com/pokegoapi/examples/GoogleUserInteractionExample.java
@@ -1,0 +1,47 @@
+/*
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pokegoapi.examples;
+
+
+import com.pokegoapi.auth.GoogleUserCredentialProvider;
+import com.pokegoapi.exceptions.LoginFailedException;
+import com.pokegoapi.exceptions.RemoteServerException;
+import okhttp3.OkHttpClient;
+
+
+import java.util.Scanner;
+
+public class GoogleUserInteractionExample {
+
+
+	public static void main(String[] args) {
+		OkHttpClient http = new OkHttpClient();
+		GoogleUserCredentialProvider provider = null;
+		try {
+
+			provider = new GoogleUserCredentialProvider(http);
+			System.out.println("Please go to " + provider.LOGIN_URL);
+			System.out.println("Enter authorisation code:");
+			Scanner sc = new Scanner(System.in);
+			String access = sc.nextLine();
+			provider.login(access);
+			System.out.println("Refresh token:" + provider.getRefreshToken());
+		} catch (LoginFailedException | RemoteServerException e) {
+			e.printStackTrace();
+		}
+
+	}
+}


### PR DESCRIPTION
Added new oauth for google user interaction to supercede GoogleCredentialProvider (example included) added a new hasLure method to Pokestops that is more reliable. Undeprecrated constructors that construct time objects by default
