### PR TITLE
Fixed Pokestop.hasLurePokemon when returning false with an active lure on it

### DIFF
--- a/src/main/java/com/pokegoapi/api/map/fort/Pokestop.java
+++ b/src/main/java/com/pokegoapi/api/map/fort/Pokestop.java
@@ -188,7 +188,7 @@ public class Pokestop {
 	 */
 	@Deprecated
 	public boolean hasLurePokemon() {
-		return fortData.hasLureInfo() && fortData.getLureInfo().getLureExpiresTimestampMs() < api.currentTimeMillis();
+		return fortData.hasLureInfo() && fortData.getLureInfo().getLureExpiresTimestampMs() > api.currentTimeMillis();
 	}
 
 	/**


### PR DESCRIPTION
**Changes made:**
- Pokestop.hasLurePokemon will now properly return true if the Pokestop has a Lure Pokemon on it and the Lure Module is active.
