### PR TITLE
Fix expiration time issues related to Wild Pokemon

### DIFF
--- a/src/main/java/com/pokegoapi/api/map/MapObjects.java
+++ b/src/main/java/com/pokegoapi/api/map/MapObjects.java
@@ -82,7 +82,11 @@ public class MapObjects {
 			return;
 		}
 		complete = true;
-		this.catchablePokemons.addAll(catchablePokemons);
+		for (MapPokemon p : catchablePokemons) {
+			if (p.getExpirationTimestampMs() != -1 ) {
+				this.catchablePokemons.add(p);
+			}
+		}
 	}
 
 	/**

--- a/src/main/java/com/pokegoapi/api/map/MapObjects.java
+++ b/src/main/java/com/pokegoapi/api/map/MapObjects.java
@@ -82,11 +82,7 @@ public class MapObjects {
 			return;
 		}
 		complete = true;
-		for (MapPokemon p : catchablePokemons) {
-			if (p.getExpirationTimestampMs() != -1 ) {
-				this.catchablePokemons.add(p);
-			}
-		}
+		this.catchablePokemons.addAll(catchablePokemons);
 	}
 
 	/**

--- a/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
+++ b/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
@@ -99,7 +99,7 @@ public class CatchablePokemon {
 		this.spawnPointId = proto.getSpawnPointId();
 		this.encounterId = proto.getEncounterId();
 		this.pokemonId = proto.getPokemonData().getPokemonId();
-		this.expirationTimestampMs = proto.getTimeTillHiddenMs();
+		this.expirationTimestampMs = proto.getLastModifiedTimestampMs() + proto.getTimeTillHiddenMs();
 		this.latitude = proto.getLatitude();
 		this.longitude = proto.getLongitude();
 	}


### PR DESCRIPTION
**Fixed issue:** [Reference the issue number here, or remove if not a fix]
#250 WildPokemon getTimeTillHiddenMs() returns large negative numbers

**Changes made:**

Wild pokemon have two fields in the protobuf;
LastModifiedTimestampMs and TimeTillHiddenMs. (The
TimeTillHiddenMs will often be a negative number, see below).

Example:
LastModifiedTimestampMs: 1469902449401
TimeTillHiddenMs: -1023634170

**(edit)** I didn't complete this thought, sorry. 
To get the actual expire time, you need to add them together.

I'm not entirely sure why occasionally TimeTillHiddenMs is a large negative number, resulting in a time in the past. I need to do some more research and see if the pokemon itself is actually spawned where it says it is even though the expiration is in the past.

In addition, you will also see that in a single query you get back
the same Pokemon (same encounter id) in both Wild and Catchable.
The catchable will have a -1 expiration time if the above happens.

I've modified the CatchablePokemon constructor to calculate the
correct expiration time for WildPokemon and also screen out the
-1 expiration Catchables in MapObjects.addCatchablePokemons()
(They're going to be in the Wild array with the correct expiration)
