### PR TITLE
Add getters to the private Pokemon(Move)Meta EnumMaps

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/pokemon/PokemonMetaRegistry.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/PokemonMetaRegistry.java
@@ -18,12 +18,15 @@ package com.pokegoapi.api.pokemon;
 import POGOProtos.Enums.PokemonFamilyIdOuterClass.PokemonFamilyId;
 import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
 import POGOProtos.Enums.PokemonMoveOuterClass.PokemonMove;
+import lombok.Getter;
 
 import java.util.EnumMap;
 
 public class PokemonMetaRegistry {
 
+	@Getter
 	private static EnumMap<PokemonFamilyId, PokemonId> highestForFamily = new EnumMap<>(PokemonFamilyId.class);
+	@Getter
 	private static EnumMap<PokemonId, PokemonMeta> meta = new EnumMap<>(PokemonId.class);
 
 	static {

--- a/library/src/main/java/com/pokegoapi/api/pokemon/PokemonMoveMetaRegistry.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/PokemonMoveMetaRegistry.java
@@ -16,11 +16,13 @@
 package com.pokegoapi.api.pokemon;
 
 import POGOProtos.Enums.PokemonMoveOuterClass.PokemonMove;
+import lombok.Getter;
 
 import java.util.EnumMap;
 
 public class PokemonMoveMetaRegistry {
 
+	@Getter
 	private static EnumMap<PokemonMove, PokemonMoveMeta> meta = new EnumMap<>(PokemonMove.class);
 
 	static {


### PR DESCRIPTION
**Fixed issue:** At this moment it is not possible to get the whole EnumMap of Pokemon(Move)Meta.

**Changes made:**
- Since the class variables were private (probably with a reason) I kept them like that but added getters to the EnumMaps to fetch them as a whole.

I hope this is no problem and correct?
