### PR TITLE
Use EnumMap instead of HashMap when the map key is an enum

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/inventory/Pokedex.java
+++ b/library/src/main/java/com/pokegoapi/api/inventory/Pokedex.java
@@ -20,7 +20,6 @@ import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
 import com.pokegoapi.api.PokemonGo;
 
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.Map;
 
 public class Pokedex {
@@ -34,7 +33,7 @@ public class Pokedex {
 
 	public void reset(PokemonGo pgo) {
 		this.api = pgo;
-		pokedexMap = new HashMap<>();
+		pokedexMap = new EnumMap<PokemonId, PokedexEntry>(PokemonId.class);
 	}
 
 	/**

--- a/library/src/main/java/com/pokegoapi/api/inventory/Pokedex.java
+++ b/library/src/main/java/com/pokegoapi/api/inventory/Pokedex.java
@@ -19,13 +19,14 @@ import POGOProtos.Data.PokedexEntryOuterClass.PokedexEntry;
 import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
 import com.pokegoapi.api.PokemonGo;
 
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
 public class Pokedex {
 
 	private PokemonGo api;
-	private Map<PokemonId, PokedexEntry> pokedexMap = new HashMap<>();
+	private Map<PokemonId, PokedexEntry> pokedexMap = new EnumMap<>(PokemonId.class);
 
 	public Pokedex(PokemonGo pgo) {
 		reset(pgo);

--- a/library/src/main/java/com/pokegoapi/api/player/PlayerProfile.java
+++ b/library/src/main/java/com/pokegoapi/api/player/PlayerProfile.java
@@ -41,6 +41,7 @@ import com.pokegoapi.main.ServerRequest;
 import com.pokegoapi.util.Log;
 import lombok.Setter;
 
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -53,7 +54,7 @@ public class PlayerProfile {
 	private PlayerAvatar avatar;
 	private DailyBonus dailyBonus;
 	private ContactSettings contactSettings;
-	private Map<Currency, Integer> currencies = new HashMap<Currency, Integer>();
+	private Map<Currency, Integer> currencies = new EnumMap<Currency, Integer>(Currency.class);
 	@Setter
 	private Stats stats;
 

--- a/library/src/main/java/com/pokegoapi/api/player/PlayerProfile.java
+++ b/library/src/main/java/com/pokegoapi/api/player/PlayerProfile.java
@@ -17,7 +17,6 @@ package com.pokegoapi.api.player;
 
 import POGOProtos.Data.Player.CurrencyOuterClass;
 import POGOProtos.Data.Player.EquippedBadgeOuterClass.EquippedBadge;
-import POGOProtos.Data.Player.PlayerStatsOuterClass;
 import POGOProtos.Data.PlayerDataOuterClass.PlayerData;
 import POGOProtos.Inventory.Item.ItemAwardOuterClass.ItemAward;
 import POGOProtos.Networking.Requests.Messages.CheckAwardedBadgesMessageOuterClass.CheckAwardedBadgesMessage;
@@ -42,7 +41,6 @@ import com.pokegoapi.util.Log;
 import lombok.Setter;
 
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.Map;
 
 

--- a/library/src/main/java/com/pokegoapi/api/pokemon/EvolutionInfo.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/EvolutionInfo.java
@@ -1,6 +1,7 @@
 package com.pokegoapi.api.pokemon;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -245,7 +246,7 @@ class EvolutionInfo {
 	private static final PokemonId[] MEWTWO_EVOLUTION = {MEWTWO};
 	private static final PokemonId[] MEW_EVOLUTION = {MEW};
 
-	private static final Map<PokemonId, PokemonId[]> EVOLUTION_INFO = new HashMap<>();
+	private static final Map<PokemonId, PokemonId[]> EVOLUTION_INFO = new EnumMap<>(PokemonId.class);
 
 	static {
 		EVOLUTION_INFO.put(BULBASAUR, BULBASAUR_EVOLUTION);

--- a/library/src/main/java/com/pokegoapi/api/pokemon/EvolutionInfo.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/EvolutionInfo.java
@@ -2,12 +2,9 @@ package com.pokegoapi.api.pokemon;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-
-import POGOProtos.Enums.PokemonIdOuterClass;
 
 import static POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
 import static POGOProtos.Enums.PokemonIdOuterClass.PokemonId.ABRA;


### PR DESCRIPTION
In a few places, HashMaps are being used with a map where the key is an Enum - in java there 
is a specialized map called the `EnumMap` that is more performant / memory efficient that you can use.  

I found a few places that could benefit from using an EnumMap
