### PR TITLE
Fix VAPOREON, JOLTEON, FLAREON `getMaxCpFullEvolveAndPowerup` return wrong CP

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/pokemon/PokemonDetails.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/PokemonDetails.java
@@ -307,6 +307,8 @@ public class PokemonDetails {
 		PokemonIdOuterClass.PokemonId highestUpgradedFamily;
 		if (getPokemonId() == EEVEE) {
 			highestUpgradedFamily = FLAREON;
+		} else if(asList(VAPOREON, JOLTEON, FLAREON).contains(getPokemonId())){
+			highestUpgradedFamily = getPokemonId();
 		} else {
 			highestUpgradedFamily = PokemonMetaRegistry.getHightestForFamily(getPokemonFamily());
 		}


### PR DESCRIPTION
Happens on Vaporeon, Jolteon, Flareon.

When call `getMaxCpFullEvolveAndPowerup()`:

In `PokemonDetails.java` line 308-312:

```
if (getPokemonId() == EEVEE) {
    highestUpgradedFamily = FLAREON;
} else {
    highestUpgradedFamily = PokemonMetaRegistry.getHightestForFamily(getPokemonFamily());
}
```

`getPokemonId()` returns VAPOREON, JOLTEON, FLAREON, which will execute `PokemonMetaRegistry.getHightestForFamily(getPokemonFamily());`

`getPokemonFamily()` returns [`FAMILY_EEVEE`](https://github.com/AeonLucid/POGOProtos/blob/b65d4b56f02a1182bd81572bcee3a32944c47885/src/POGOProtos/Enums/PokemonFamilyId.proto)

So, `PokemonMetaRegistry.getMeta()` returns Eevee's meta.
