### PR TITLE
Added and fixed methods in Pokemon.java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,4 +158,3 @@ fabric.properties
 .LSOverride
 
 
-*.checkstyle

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ fabric.properties
 .LSOverride
 
 
+*.checkstyle

--- a/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
@@ -179,6 +179,27 @@ public class Pokemon extends PokemonDetails {
 	}
 	
 	/**
+	 * Check if can powers up this pokemon, you can choose whether or not to consider the max cp limit for current
+	 * player level passing true to consider and false to not consider.
+	 * 
+	 * @param  considerMaxCPLimitForPlayerLevel Consider max cp limit for actual player level
+	 * @return the boolean
+	 * @throws LoginFailedException  the login failed exception
+	 * @throws RemoteServerException the remote server exception
+	 * @throws NoSuchItemException   If the PokemonId value cannot be found in the {@link PokemonMetaRegistry}.
+	 */
+	public boolean canPowerUp(boolean considerMaxCPLimitForPlayerLevel)
+		throws LoginFailedException, RemoteServerException, NoSuchItemException {
+	    boolean result = false;
+	    if (considerMaxCPLimitForPlayerLevel) {
+	    	result = (this.canPowerUp() && (this.getCp() < this.getMaxCpForPlayer()));
+	    } else {
+	    	result = this.canPowerUp();
+	    }
+	    return result;
+	}
+	
+	/**
 	 * Check if can evolve this pokemon
 	 *
 	 * @return the boolean

--- a/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
@@ -207,7 +207,7 @@ public class Pokemon extends PokemonDetails {
 	 * @throws RemoteServerException the remote server exception
 	 */
 	public boolean canEvolve() throws LoginFailedException, RemoteServerException {
-		return ((!EvolutionInfo.isFullyEvolved(this.getPokemonId())) && (getCandy() >= getCandiesToEvolve()));
+		return !EvolutionInfo.isFullyEvolved(getPokemonId()) && (getCandy() >= getCandiesToEvolve());
 	}
 
 	/**

--- a/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
@@ -179,6 +179,27 @@ public class Pokemon extends PokemonDetails {
 	}
 	
 	/**
+	 * Check if can powers up this pokemon, you can choose whether or not to consider the max cp limit for current
+	 * player level passing true to consider and false to not consider.
+	 * 
+	 * @param  considerMaxCPLimitForPlayerLevel Consider max cp limit for actual player level
+	 * @return the boolean
+	 * @throws LoginFailedException  the login failed exception
+	 * @throws RemoteServerException the remote server exception
+	 * @throws NoSuchItemException   If the PokemonId value cannot be found in the {@link PokemonMetaRegistry}.
+	 */
+	public boolean canPowerUp(boolean considerMaxCPLimitForPlayerLevel)
+		throws LoginFailedException, RemoteServerException, NoSuchItemException {
+		boolean result = false;
+		if (considerMaxCPLimitForPlayerLevel) {
+			result = (this.canPowerUp() && (this.getCp() < this.getMaxCpForPlayer()));
+		} else {
+			result = this.canPowerUp();
+		}
+		return result;
+	}
+	
+	/**
 	 * Check if can evolve this pokemon
 	 *
 	 * @return the boolean

--- a/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
@@ -179,27 +179,6 @@ public class Pokemon extends PokemonDetails {
 	}
 	
 	/**
-	 * Check if can powers up this pokemon, you can choose whether or not to consider the max cp limit for current
-	 * player level passing true to consider and false to not consider.
-	 * 
-	 * @param  considerMaxCPLimitForPlayerLevel Consider max cp limit for actual player level
-	 * @return the boolean
-	 * @throws LoginFailedException  the login failed exception
-	 * @throws RemoteServerException the remote server exception
-	 * @throws NoSuchItemException   If the PokemonId value cannot be found in the {@link PokemonMetaRegistry}.
-	 */
-	public boolean canPowerUp(boolean considerMaxCPLimitForPlayerLevel)
-		throws LoginFailedException, RemoteServerException, NoSuchItemException {
-	    boolean result = false;
-	    if (considerMaxCPLimitForPlayerLevel) {
-	    	result = (this.canPowerUp() && (this.getCp() < this.getMaxCpForPlayer()));
-	    } else {
-	    	result = this.canPowerUp();
-	    }
-	    return result;
-	}
-	
-	/**
 	 * Check if can evolve this pokemon
 	 *
 	 * @return the boolean

--- a/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
@@ -189,10 +189,10 @@ public class Pokemon extends PokemonDetails {
 	 * @throws NoSuchItemException   If the PokemonId value cannot be found in the {@link PokemonMetaRegistry}.
 	 */
 	public boolean canPowerUp(boolean considerMaxCPLimitForPlayerLevel)
-		throws LoginFailedException, RemoteServerException, NoSuchItemException {
-		return considerMaxCPLimitForPlayerLevel 
-				? this.canPowerUp() && (this.getCp() < this.getMaxCpForPlayer())
-                : canPowerUp();
+			throws LoginFailedException, RemoteServerException, NoSuchItemException {
+		return considerMaxCPLimitForPlayerLevel
+				? this.canPowerUp() && (this.getCp() < this.getMaxCpForPlayer()) 
+						: canPowerUp();
 	}
 	
 	/**

--- a/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
@@ -190,13 +190,9 @@ public class Pokemon extends PokemonDetails {
 	 */
 	public boolean canPowerUp(boolean considerMaxCPLimitForPlayerLevel)
 		throws LoginFailedException, RemoteServerException, NoSuchItemException {
-		boolean result = false;
-		if (considerMaxCPLimitForPlayerLevel) {
-			result = (this.canPowerUp() && (this.getCp() < this.getMaxCpForPlayer()));
-		} else {
-			result = this.canPowerUp();
-		}
-		return result;
+		return considerMaxCPLimitForPlayerLevel 
+				? this.canPowerUp() && (this.getCp() < this.getMaxCpForPlayer())
+                : canPowerUp();
 	}
 	
 	/**

--- a/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
@@ -190,9 +190,9 @@ public class Pokemon extends PokemonDetails {
 	 */
 	public boolean canPowerUp(boolean considerMaxCPLimitForPlayerLevel)
 			throws LoginFailedException, RemoteServerException, NoSuchItemException {
-		return considerMaxCPLimitForPlayerLevel
-				? this.canPowerUp() && (this.getCp() < this.getMaxCpForPlayer()) 
-						: canPowerUp();
+		return considerMaxCPLimitForPlayerLevel 
+				? this.canPowerUp() && (this.getCp() < this.getMaxCpForPlayer())
+				: canPowerUp();
 	}
 	
 	/**

--- a/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
@@ -186,7 +186,7 @@ public class Pokemon extends PokemonDetails {
 	 * @throws RemoteServerException the remote server exception
 	 */
 	public boolean canEvolve() throws LoginFailedException, RemoteServerException {
-		return getCandy() >= getCandiesToEvolve();
+		return ((!EvolutionInfo.isFullyEvolved(this.getPokemonId())) && (getCandy() >= getCandiesToEvolve()));
 	}
 
 	/**


### PR DESCRIPTION
**Changes made:**
- Fixed Pokemon.canEvolve():boolean, now it checks if the pokemon already reached the maximum evolution form;
- Added Pokemon.canPowerUp(considerMaxCPLimitForPlayerLevel:boolean):boolean so now passing true it checks if the pokemon is already at its current maximum cp for player level;

**Note:**
I added a new canPowerUp method (and not modified the original one) because of issue #622, it will work better after the resolution, so for now I implemented it as an "optional";
