### PR TITLE
Fix razz berries usage

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/settings/CatchOptions.java
+++ b/library/src/main/java/com/pokegoapi/api/settings/CatchOptions.java
@@ -198,8 +198,8 @@ public class CatchOptions {
 	 */
 	public int getRazzberries() {
 		int razzberries = maxRazzBerries;
-		if (useRazzBerries && maxRazzBerries <= 1) {
-			razzberries = 1;
+		if(!useRazzBerries){
+			return 0;
 		} else if (maxRazzBerries <= 0) {
 			razzberries = -1;
 		} else {


### PR DESCRIPTION
**Changes made:**
in the old code if useRazzBerries was set to false then it would either return maxRazzBerries if maxRazzBerries > 0 or -1 (unlimited) if set to 0 or less.
atm theres no way to use CatchOptions object without using razz berries.
