### PR TITLE
Fix maxRazzberries for intended functionality

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/settings/CatchOptions.java
+++ b/library/src/main/java/com/pokegoapi/api/settings/CatchOptions.java
@@ -66,7 +66,7 @@ public class CatchOptions {
 	public CatchOptions(PokemonGo api) {
 		this.api = api;
 		this.useRazzBerries = false;
-		this.maxRazzBerries = -1;
+		this.maxRazzBerries = 0;
 		this.useBestPokeball = false;
 		this.skipMasterBall = false;
 		this.pokeBall = POKEBALL;
@@ -197,15 +197,7 @@ public class CatchOptions {
 	 * @return the number to use
 	 */
 	public int getRazzberries() {
-		int razzberries = maxRazzBerries;
-		if (useRazzBerries && maxRazzBerries <= 1) {
-			razzberries = 1;
-		} else if (maxRazzBerries <= 0) {
-			razzberries = -1;
-		} else {
-			razzberries = maxRazzBerries;
-		}
-		return razzberries;
+		return useRazzBerries && maxRazzBerries == 0 ? 1 : maxRazzBerries;
 	}
 	
 	/**


### PR DESCRIPTION
Performs the intended fix of https://github.com/Grover-c13/PokeGOAPI-Java/pull/634 without changing the functionality

This should allow setting true when no max exists to use 1, but allow
setting a max of more than 1 to supersede leaving use as false
