### PR TITLE
Improve login stability

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/PokemonGo.java
+++ b/library/src/main/java/com/pokegoapi/api/PokemonGo.java
@@ -41,6 +41,7 @@ import java.util.Random;
 public class PokemonGo {
 
 	private static final java.lang.String TAG = PokemonGo.class.getSimpleName();
+	private static final int sleepTime = 800;
 	private final Time time;
 	public final long startTime;
 	@Getter
@@ -72,11 +73,13 @@ public class PokemonGo {
 	 * @param credentialProvider the credential provider
 	 * @param client             the http client
 	 * @param time               a time implementation
+	 * @param needSleep			 need sleep after creating settings
 	 * @throws LoginFailedException  When login fails
 	 * @throws RemoteServerException When server fails
+	 * @throws InterruptedException When Thread.sleep fails
 	 */
 
-	public PokemonGo(CredentialProvider credentialProvider, OkHttpClient client, Time time)
+	public PokemonGo(CredentialProvider credentialProvider, OkHttpClient client, Time time, boolean needSleep)
 			throws LoginFailedException, RemoteServerException, InterruptedException {
 
 		if (credentialProvider == null) {
@@ -91,14 +94,34 @@ public class PokemonGo {
 
 		requestHandler = new RequestHandler(this, client);
 		playerProfile = new PlayerProfile(this);
-		Thread.sleep(800);
+		//Need to sleep after PlayerProfile's updateProfile()
+		if (needSleep) Thread.sleep(sleepTime);
+		
 		settings = new Settings(this);
-		Thread.sleep(800);
+		//Need to sleep after Settings' updateSettings()
+		if (needSleep) Thread.sleep(sleepTime);
+		
 		map = new Map(this);
 		longitude = Double.NaN;
 		latitude = Double.NaN;
 		startTime = currentTimeMillis();
 	}
+
+	/**
+	 * Instantiates a new Pokemon go asking which will sleep after settings.
+	 *
+	 * @param credentialProvider the credential provider
+	 * @param client             the http client
+	 * @param needSleep			 need sleep after creating settings
+	 * @throws LoginFailedException  When login fails
+	 * @throws RemoteServerException When server fails
+	 * @throws InterruptedException When Thread.sleep fails
+	 */
+	public PokemonGo(CredentialProvider credentialProvider, OkHttpClient client, boolean needSleep)
+			throws LoginFailedException, RemoteServerException, InterruptedException {
+		this(credentialProvider, client, new SystemTimeImpl(), needSleep);
+	}
+
 
 	/**
 	 * Instantiates a new Pokemon go.
@@ -108,10 +131,11 @@ public class PokemonGo {
 	 * @param client             the http client
 	 * @throws LoginFailedException  When login fails
 	 * @throws RemoteServerException When server fails
+	 * @throws InterruptedException When Thread.sleep fails
 	 */
 	public PokemonGo(CredentialProvider credentialProvider, OkHttpClient client)
 			throws LoginFailedException, RemoteServerException, InterruptedException {
-		this(credentialProvider, client, new SystemTimeImpl());
+		this(credentialProvider, client, new SystemTimeImpl(), false);
 	}
 
 	/**

--- a/library/src/main/java/com/pokegoapi/api/PokemonGo.java
+++ b/library/src/main/java/com/pokegoapi/api/PokemonGo.java
@@ -77,7 +77,7 @@ public class PokemonGo {
 	 */
 
 	public PokemonGo(CredentialProvider credentialProvider, OkHttpClient client, Time time)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, RemoteServerException, InterruptedException {
 
 		if (credentialProvider == null) {
 			throw new LoginFailedException("Credential Provider is null");
@@ -91,7 +91,9 @@ public class PokemonGo {
 
 		requestHandler = new RequestHandler(this, client);
 		playerProfile = new PlayerProfile(this);
+		Thread.sleep(800);
 		settings = new Settings(this);
+		Thread.sleep(800);
 		map = new Map(this);
 		longitude = Double.NaN;
 		latitude = Double.NaN;
@@ -108,7 +110,7 @@ public class PokemonGo {
 	 * @throws RemoteServerException When server fails
 	 */
 	public PokemonGo(CredentialProvider credentialProvider, OkHttpClient client)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, RemoteServerException, InterruptedException {
 		this(credentialProvider, client, new SystemTimeImpl());
 	}
 


### PR DESCRIPTION
**Fixed issue:** Improved PokemonGo.java constructor (and hence login) stability

**Changes made:**
- Added sleep after PlayerProfile() and Settings() because they request info from the server. From some previous issues, we know that we need some time delay between request.
- The sleep will only be turned on after adding a "true" argument to the constructor so that it doesn't break existing code
- Parametrized the sleep time
