### PR TITLE
Fix clearing the cache and refilling lists

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/PokemonGo.java
+++ b/library/src/main/java/com/pokegoapi/api/PokemonGo.java
@@ -253,9 +253,7 @@ public class PokemonGo {
 	 * @param altitude  the altitude
 	 */
 	public void setLocation(double latitude, double longitude, double altitude) {
-		if (latitude != this.latitude
-				|| longitude != this.longitude
-				|| altitude != this.altitude) {
+		if (latitude != this.latitude || longitude != this.longitude) {
 			getMap().clearCache();
 		}
 		setLatitude(latitude);

--- a/library/src/main/java/com/pokegoapi/api/map/Map.java
+++ b/library/src/main/java/com/pokegoapi/api/map/Map.java
@@ -94,13 +94,7 @@ public class Map {
 	 */
 	public Observable<List<CatchablePokemon>> getCatchablePokemonAsync() {
 
-		if (!useCache()) {
-			// getMapObjects wont be called unless this is null
-			// so need to force it if due for a refresh
-			cachedCatchable.clear();
-		}
-
-		if (cachedCatchable.size() > 0) {
+		if (useCache() && cachedCatchable.size() > 0) {
 			return Observable.just(cachedCatchable);
 		}
 
@@ -338,7 +332,7 @@ public class Map {
 	 */
 	public Observable<MapObjects> getMapObjectsAsync(List<Long> cellIds) {
 
-		if (useCache()) {
+		if (useCache() && cachedCatchable.size() > 0) {
 			return Observable.just(cachedMapObjects);
 		}
 


### PR DESCRIPTION
- Do not clear the cache to move to the exact spot at higher altitude
- Check that both the cache is to be used AND there are objects in it

Note: There is no master check for cached map objects, so the most
commonly filled object was used instead (cachedCatchable)
