### PR TITLE
Fixed Issue #694: Freeze on Locale Fallback on Android

### DIFF
--- a/library/src/main/java/com/pokegoapi/util/PokeDictionary.java
+++ b/library/src/main/java/com/pokegoapi/util/PokeDictionary.java
@@ -46,12 +46,7 @@ public class PokeDictionary {
 
 	private static ResourceBundle getPokeBundle(String bundleBaseName, Locale locale)
 			throws MissingResourceException {
-		return ResourceBundle.getBundle(bundleBaseName, locale, new ResourceBundle.Control() {
-			@Override
-			public Locale getFallbackLocale(String baseName, Locale locale) {
-				return Locale.ENGLISH;
-			}
-		});
+		return ResourceBundle.getBundle(bundleBaseName, locale);
 	}
 
 	/**


### PR DESCRIPTION
**Fixed issue:** #694 

**Changes made:**
- removed a few lines, see diff

I tested this fix on Android 6.0 with following default locales:
German -> fallback to German
English (Canadian) -> fallback to English
Chinese -> fallback to English

_Note: Don't mind the wrong issue number in my commit name. It references to my faulty pull request that caused this issue, instead of the actual issue report. However, if you tell me how to rename it, I can do that._
