### PR TITLE
Map: append common requests to GetMapObject

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/map/Map.java
+++ b/library/src/main/java/com/pokegoapi/api/map/Map.java
@@ -33,6 +33,7 @@ import com.pokegoapi.google.common.geometry.MutableInteger;
 import com.pokegoapi.google.common.geometry.S2CellId;
 import com.pokegoapi.google.common.geometry.S2LatLng;
 import com.pokegoapi.main.AsyncServerRequest;
+import com.pokegoapi.main.CommonRequest;
 import com.pokegoapi.main.ServerRequest;
 import com.pokegoapi.util.AsyncHelper;
 import com.pokegoapi.util.MapUtil;
@@ -60,9 +61,11 @@ import POGOProtos.Networking.Requests.Messages.GetMapObjectsMessageOuterClass;
 import POGOProtos.Networking.Requests.Messages.GetMapObjectsMessageOuterClass.GetMapObjectsMessage;
 import POGOProtos.Networking.Requests.RequestTypeOuterClass.RequestType;
 import POGOProtos.Networking.Responses.CatchPokemonResponseOuterClass.CatchPokemonResponse;
+import POGOProtos.Networking.Responses.DownloadSettingsResponseOuterClass.DownloadSettingsResponse;
 import POGOProtos.Networking.Responses.EncounterResponseOuterClass.EncounterResponse;
 import POGOProtos.Networking.Responses.FortDetailsResponseOuterClass;
 import POGOProtos.Networking.Responses.FortSearchResponseOuterClass.FortSearchResponse;
+import POGOProtos.Networking.Responses.GetInventoryResponseOuterClass.GetInventoryResponse;
 import POGOProtos.Networking.Responses.GetMapObjectsResponseOuterClass.GetMapObjectsResponse;
 import rx.Observable;
 import rx.functions.Func1;
@@ -350,7 +353,7 @@ public class Map {
 
 		final AsyncServerRequest asyncServerRequest = new AsyncServerRequest(
 				RequestType.GET_MAP_OBJECTS, builder.build());
-		return api.getRequestHandler()
+		Observable<MapObjects> mapObjects = api.getRequestHandler()
 				.sendAsyncServerRequests(asyncServerRequest).map(new Func1<ByteString, MapObjects>() {
 					@Override
 					public MapObjects call(ByteString byteString) {
@@ -385,6 +388,25 @@ public class Map {
 						return result;
 					}
 				});
+
+		ServerRequest[] requests = CommonRequest.commonRequests(api);
+
+		try {
+			api.getRequestHandler().sendServerRequests(requests);
+		} catch (RemoteServerException e) {
+			throw new AsyncRemoteServerException(e);
+		} catch (LoginFailedException e) {
+			throw new AsyncRemoteServerException(e);
+		}
+
+		try {
+			api.getInventories().updateInventories(GetInventoryResponse.parseFrom(requests[1].getData()));
+			api.getSettings().updateSettings(DownloadSettingsResponse.parseFrom(requests[3].getData()));
+		} catch (InvalidProtocolBufferException e) {
+			throw new AsyncRemoteServerException(e);
+		}
+
+		return mapObjects;
 	}
 
 	/**
@@ -684,7 +706,6 @@ public class Map {
 
 	/**
 	 * Clear map objects cache
-	 *
 	 */
 	public void clearCache() {
 		cachedCatchable.clear();

--- a/library/src/main/java/com/pokegoapi/main/CommonRequest.java
+++ b/library/src/main/java/com/pokegoapi/main/CommonRequest.java
@@ -104,4 +104,24 @@ public class CommonRequest {
 				CommonRequest.getDownloadSettingsMessageRequest(api));
 		return serverRequests;
 	}
+
+	/**
+	 * List of common requests
+	 *
+	 * @param api The current instance of PokemonGO
+	 * @return an array of ServerRequest
+	 *
+	 */
+	public static ServerRequest[] commonRequests(PokemonGo api) {
+		ServerRequest[] serverRequests = new ServerRequest[4];
+		serverRequests[0] = new ServerRequest(RequestType.GET_HATCHED_EGGS,
+				GetHatchedEggsMessage.getDefaultInstance());
+		serverRequests[1] = new ServerRequest(RequestType.GET_INVENTORY,
+				CommonRequest.getDefaultGetInventoryMessage(api));
+		serverRequests[2] = new ServerRequest(RequestType.CHECK_AWARDED_BADGES,
+				CheckAwardedBadgesMessage.getDefaultInstance());
+		serverRequests[3] = new ServerRequest(RequestType.DOWNLOAD_SETTINGS,
+				CommonRequest.getDownloadSettingsMessageRequest(api));
+		return serverRequests;
+	}
 }


### PR DESCRIPTION
I'll wait for your ok to merge this but imho, is good to have this inside.
getMapObject request on official client is always append on top of the other 4 common requests. 
From what we can understand from the dump the logic of how the requests are fired is quite simple. There is a loop of 5 requests that are always fired together. The first request, on top of the other, could be anything (such as the getMapObject or others like DownloadItemTemplates etc.etc.). All of these, are followed by a set of 4 requests that are now inside the CommonRequest class. 

O.T: I'll provide later on a more generalization on how the responses are managed by the library. Actually I'm copy pasting how the responses of the 4 subsequent calls are handled, but as said, I'm going to generalize also these. 
