### PR TITLE
Prefer user values to maintain consistency

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/PokemonGo.java
+++ b/library/src/main/java/com/pokegoapi/api/PokemonGo.java
@@ -328,4 +328,18 @@ public class PokemonGo {
 		}
 		return deviceInfo.getDeviceInfo();
 	}
+	
+	/**
+	 * Gets the sensor info
+	 *
+	 * @param currentTime the current time
+	 * @param random      the random object
+	 * @return the sensor info
+	 */
+	public SignatureOuterClass.Signature.SensorInfo getSensorSignature(long currentTime, Random random) {
+		if (sensorInfo == null || sensorInfo.getTimestampCreate() != 0L) {
+			return SensorInfo.getDefault(this, currentTime, random);
+		}
+		return sensorInfo.getSensorInfo();
+	}
 }

--- a/library/src/main/java/com/pokegoapi/api/PokemonGo.java
+++ b/library/src/main/java/com/pokegoapi/api/PokemonGo.java
@@ -337,9 +337,22 @@ public class PokemonGo {
 	 * @return the sensor info
 	 */
 	public SignatureOuterClass.Signature.SensorInfo getSensorSignature(long currentTime, Random random) {
-		if (sensorInfo == null || sensorInfo.getTimestampCreate() != 0L) {
+		if (sensorInfo.getSensorInfo() == null || sensorInfo.getTimestampCreate() != 0L) {
 			return SensorInfo.getDefault(this, currentTime, random);
 		}
 		return sensorInfo.getSensorInfo();
+	}
+	
+	/**
+	 * Gets the activity status
+	 *
+	 * @param random the random object
+	 * @return the activity status
+	 */
+	public SignatureOuterClass.Signature.ActivityStatus getActivitySignature(Random random) {
+		if (activityStatus.getActivityStatus() == null) {
+			return ActivityStatus.getDefault(this, random);
+		}
+		return activityStatus.getActivityStatus();
 	}
 }

--- a/library/src/main/java/com/pokegoapi/api/PokemonGo.java
+++ b/library/src/main/java/com/pokegoapi/api/PokemonGo.java
@@ -109,6 +109,7 @@ public class PokemonGo {
 		map = new Map(this);
 		longitude = Double.NaN;
 		latitude = Double.NaN;
+		altitude = Double.NaN;
 	}
 
 	/**

--- a/library/src/main/java/com/pokegoapi/api/device/LocationFixes.java
+++ b/library/src/main/java/com/pokegoapi/api/device/LocationFixes.java
@@ -79,6 +79,9 @@ public class LocationFixes extends ArrayList<SignatureOuterClass.Signature.Locat
 			float latitude = offsetOnLatLong(api.getLatitude(), random.nextInt(100) + 10);
 			float longitude = offsetOnLatLong(api.getLongitude(), random.nextInt(100) + 10);
 			float altitude = 65;
+			if (api.getAltitude() != Double.NaN) {
+				altitude = (float) api.getAltitude();
+			}
 			float verticalAccuracy = (float) (15 + (23 - 15) * random.nextDouble());
 
 			// Fake errors

--- a/library/src/main/java/com/pokegoapi/api/device/LocationFixes.java
+++ b/library/src/main/java/com/pokegoapi/api/device/LocationFixes.java
@@ -78,10 +78,7 @@ public class LocationFixes extends ArrayList<SignatureOuterClass.Signature.Locat
 		for (int i = 0; i < providerCount; i++) {
 			float latitude = offsetOnLatLong(api.getLatitude(), random.nextInt(100) + 10);
 			float longitude = offsetOnLatLong(api.getLongitude(), random.nextInt(100) + 10);
-			float altitude = 65;
-			if (api.getAltitude() != Double.NaN) {
-				altitude = (float) api.getAltitude();
-			}
+			float altitude = (float) api.getAltitude();
 			float verticalAccuracy = (float) (15 + (23 - 15) * random.nextDouble());
 
 			// Fake errors

--- a/library/src/main/java/com/pokegoapi/util/Signature.java
+++ b/library/src/main/java/com/pokegoapi/util/Signature.java
@@ -54,7 +54,7 @@ public class Signature {
 				.setTimestamp(api.currentTimeMillis())
 				.setTimestampSinceStart(currentTime - api.getStartTime())
 				.setDeviceInfo(api.getDeviceInfo())
-				.setActivityStatus(ActivityStatus.getDefault(api, random))
+				.setActivityStatus(api.getActivitySignature(random))
 				.addAllLocationFix(LocationFixes.getDefault(api, builder, currentTime, random))
 				.setUnknown25(Constant.UNK25);
 

--- a/library/src/main/java/com/pokegoapi/util/Signature.java
+++ b/library/src/main/java/com/pokegoapi/util/Signature.java
@@ -58,7 +58,7 @@ public class Signature {
 				.addAllLocationFix(LocationFixes.getDefault(api, builder, currentTime, random))
 				.setUnknown25(Constant.UNK25);
 
-		SignatureOuterClass.Signature.SensorInfo sensorInfo = SensorInfo.getDefault(api, currentTime, random);
+		SignatureOuterClass.Signature.SensorInfo sensorInfo = api.getSensorSignature(currentTime, random);
 		if (sensorInfo != null) {
 			sigBuilder.setSensorInfo(sensorInfo);
 		}


### PR DESCRIPTION
A random should not be used when a user value exists, since this is supposed to be signing a call by wrapping it with what should be an extended reading of the same device in the same place.

SensorInfo should favor user values before attempting to instantiate / update a default

ActivityStatus should allow user configuration and favor it before instantiating a default
