### PR TITLE
Bad Copy / Paste

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/map/Map.java
+++ b/library/src/main/java/com/pokegoapi/api/map/Map.java
@@ -332,7 +332,7 @@ public class Map {
 	 */
 	public Observable<MapObjects> getMapObjectsAsync(List<Long> cellIds) {
 
-		if (useCache() && cachedCatchable.size() > 0) {
+		if (useCache()) {
 			return Observable.just(cachedMapObjects);
 		}
 


### PR DESCRIPTION
**Changes made:**
Delete the cacheCatchable size verification to use mapObjetsCache

*\* Fix issue **
#739

No need to verifiy the size of cachedCatchable to use the cachedMapObjects.
When you use the getMapObjects().getPokestops() (so cachedCatchable == null) method first and after getCatchablePokemon(), the cachedMapObjects should be used and it is not the case.
