### PR TITLE
[Issue #758] CatchOptions#useRazzberries(boolean) not working

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
@@ -438,8 +438,16 @@ public class CatchablePokemon implements MapPoint {
 		Item razberriesInventory = api.getInventories().getItemBag().getItem(ItemId.ITEM_RAZZ_BERRY);
 		int razberries = 0;
 		int numThrows = 0;
-		Log.d("catchPokemon", String.format("attempt to catch pokemon using max %d razzberries. %d in inventory",
-				razberriesLimit, razberriesInventory.getCount()));
+		Log.d("catchPokemon",
+				String.format("attempt to catch pokemon%s.",
+						razberriesLimit > 0
+								? String.format(" using max %d razzberrys. %d in inventory",
+								razberriesLimit, razberriesInventory.getCount())
+								: razberriesLimit == -1
+								? String.format(" using all %d razzberrys in inventory",
+								razberriesInventory.getCount())
+								: " using no razzberries"
+				));
 
 		CatchResult result;
 		do {

--- a/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
@@ -252,13 +252,7 @@ public class CatchablePokemon implements MapPoint {
 	 */
 	public CatchResult catchPokemon(CatchOptions options) throws LoginFailedException,
 			RemoteServerException, NoSuchItemException {
-		if (options != null) {
-			if (options.getRazzberries() == 1) {
-				useItem(ItemId.ITEM_RAZZ_BERRY);
-				options.useRazzberries(false);
-				options.maxRazzberries(-1);
-			}
-		} else {
+		if (options == null) {
 			options = new CatchOptions(api);
 		}
 
@@ -289,13 +283,7 @@ public class CatchablePokemon implements MapPoint {
 		if (!encounter.wasSuccessful()) throw new EncounterFailedException();
 		double probability = encounter.getCaptureProbability().getCaptureProbability(0);
 
-		if (options != null) {
-			if (options.getRazzberries() == 1) {
-				useItem(ItemId.ITEM_RAZZ_BERRY);
-				options.useRazzberries(false);
-				options.maxRazzberries(-1);
-			}
-		} else {
+		if (options == null) {
 			options = new CatchOptions(api);
 		}
 

--- a/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
@@ -433,12 +433,15 @@ public class CatchablePokemon implements MapPoint {
 									double normalizedReticleSize, double spinModifier, Pokeball type,
 									int amount, int razberriesLimit)
 			throws LoginFailedException, RemoteServerException {
+
+		int razberriesInventory = api.getInventories().getItemBag().getItem(ItemId.ITEM_RAZZ_BERRY).getCount();
 		int razberries = 0;
 		int numThrows = 0;
+
 		CatchResult result;
 		do {
 
-			if (razberries < razberriesLimit || razberriesLimit == -1) {
+			if (razberriesInventory - razberries > 0 && (razberries < razberriesLimit || razberriesLimit == -1)) {
 				useItem(ItemId.ITEM_RAZZ_BERRY);
 				razberries++;
 			}

--- a/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
@@ -435,6 +435,8 @@ public class CatchablePokemon implements MapPoint {
 									int amount, int razberriesLimit)
 			throws LoginFailedException, RemoteServerException {
 
+		api.getInventories().updateInventories();
+		
 		Item razberriesInventory = api.getInventories().getItemBag().getItem(ItemId.ITEM_RAZZ_BERRY);
 		int razberries = 0;
 		int numThrows = 0;

--- a/library/src/main/java/com/pokegoapi/api/settings/CatchOptions.java
+++ b/library/src/main/java/com/pokegoapi/api/settings/CatchOptions.java
@@ -70,7 +70,7 @@ public class CatchOptions {
 	public CatchOptions(PokemonGo api) {
 		this.api = api;
 		this.useRazzBerries = false;
-		this.maxRazzBerries = 0;
+		this.maxRazzBerries = 1;
 		this.useBestPokeball = false;
 		this.skipMasterBall = false;
 		this.pokeBall = POKEBALL;
@@ -167,7 +167,7 @@ public class CatchOptions {
 	 * @return the number to use
 	 */
 	public int getRazzberries() {
-		return useRazzBerries && maxRazzBerries == 0 ? 1 : maxRazzBerries;
+		return !useRazzBerries ? 0 : maxRazzBerries;
 	}
 	
 	/**
@@ -182,7 +182,9 @@ public class CatchOptions {
 	}
 	
 	/**
-	 * Set a maximum number of razzberries
+	 * Set a maximum number of razzberries.
+	 * Default: 1
+	 * If set to -1, the maximum number is only limited by the amount of razzberries available.
 	 *
 	 * @param maxRazzBerries maximum allowed
 	 * @return               the CatchOptions object


### PR DESCRIPTION
**Fixed issue:** #758 

**Changes made:**
- removed unnecessary use of 1 razzberry prior to actual use of n razzberries
- fixed CatchOptions#getRazzberries()
- fixed bug that used more razzberries than available
- added two Log.d's that notify you about how many razzberries you're about to use on the encountered Pokémon, and how many razzberries were actually used.

I ran this with a quickly made bot for a few hours without any errors, catching about 3 Pokemon per minute.
Feel free to test this in a productive environment. I don't have any at this point.
Maybe @LoungeKatt ?
