### PR TITLE
Add CaptchaActiveException, to prevent messages being sent while captcha is active

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/PokemonGo.java
+++ b/library/src/main/java/com/pokegoapi/api/PokemonGo.java
@@ -112,6 +112,9 @@ public class PokemonGo {
 	@Getter
 	private List<Listener> listeners = new ArrayList<Listener>();
 
+	@Getter
+	private boolean loggingIn;
+
 	/**
 	 * Instantiates a new Pokemon go.
 	 *
@@ -176,6 +179,7 @@ public class PokemonGo {
 	 */
 	public void login(CredentialProvider credentialProvider)
 			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
+		this.loggingIn = true;
 		if (credentialProvider == null) {
 			throw new NullPointerException("Credential Provider is null");
 		}
@@ -186,6 +190,8 @@ public class PokemonGo {
 		inventories = new Inventories(this);
 
 		initialize();
+
+		this.loggingIn = false;
 	}
 
 	private void initialize() throws RemoteServerException, CaptchaActiveException, LoginFailedException {

--- a/library/src/main/java/com/pokegoapi/api/PokemonGo.java
+++ b/library/src/main/java/com/pokegoapi/api/PokemonGo.java
@@ -39,6 +39,7 @@ import com.pokegoapi.api.map.Map;
 import com.pokegoapi.api.player.PlayerProfile;
 import com.pokegoapi.api.settings.Settings;
 import com.pokegoapi.auth.CredentialProvider;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.main.AsyncServerRequest;
@@ -171,8 +172,10 @@ public class PokemonGo {
 	 * @param credentialProvider the credential provider
 	 * @throws LoginFailedException When login fails
 	 * @throws RemoteServerException When server fails
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void login(CredentialProvider credentialProvider) throws LoginFailedException, RemoteServerException {
+	public void login(CredentialProvider credentialProvider)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		if (credentialProvider == null) {
 			throw new NullPointerException("Credential Provider is null");
 		}
@@ -185,7 +188,7 @@ public class PokemonGo {
 		initialize();
 	}
 
-	private void initialize() throws RemoteServerException, LoginFailedException {
+	private void initialize() throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		fireRequestBlock(new ServerRequest(RequestType.DOWNLOAD_REMOTE_CONFIG_VERSION,
 				CommonRequests.getDownloadRemoteConfigVersionMessageRequest()));
 
@@ -231,8 +234,10 @@ public class PokemonGo {
 	 * @param request server request
 	 * @throws LoginFailedException When login fails
 	 * @throws RemoteServerException When server fails
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	private void fireRequestBlock(ServerRequest request) throws RemoteServerException, LoginFailedException {
+	private void fireRequestBlock(ServerRequest request)
+			throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		ServerRequest[] requests = CommonRequests.fillRequest(request, this);
 
 		getRequestHandler().sendServerRequests(requests);
@@ -249,8 +254,9 @@ public class PokemonGo {
 	 *
 	 * @throws LoginFailedException When login fails
 	 * @throws RemoteServerException When server fails
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void fireRequestBlockTwo() throws RemoteServerException, LoginFailedException {
+	public void fireRequestBlockTwo() throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		fireRequestBlock(new ServerRequest(RequestTypeOuterClass.RequestType.GET_ASSET_DIGEST,
 				CommonRequests.getGetAssetDigestMessageRequest()));
 	}
@@ -279,9 +285,10 @@ public class PokemonGo {
 	 * @return AuthInfo object
 	 * @throws LoginFailedException when login fails
 	 * @throws RemoteServerException When server fails
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public AuthInfo getAuthInfo()
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return credentialProvider.getAuthInfo();
 	}
 
@@ -398,6 +405,7 @@ public class PokemonGo {
 
 	/**
 	 * Updates the current challenge
+	 *
 	 * @param url the challenge url, if any
 	 * @param hasChallenge whether the challenge solve is required
 	 */
@@ -414,6 +422,7 @@ public class PokemonGo {
 
 	/**
 	 * Registers the given listener to this api.
+	 *
 	 * @param listener the listener to register
 	 */
 	public void addListener(Listener listener) {
@@ -431,6 +440,7 @@ public class PokemonGo {
 
 	/**
 	 * Returns all listeners for the given type.
+	 *
 	 * @param listenerType the type of listeners to return
 	 * @return all listeners for the given type
 	 */
@@ -446,6 +456,7 @@ public class PokemonGo {
 
 	/**
 	 * Invokes a method in all listeners of the given type
+	 *
 	 * @param listenerType the listener to call to
 	 * @param name the method name to call
 	 * @param parameters the parameters to pass to the method
@@ -479,14 +490,16 @@ public class PokemonGo {
 
 	/**
 	 * Verifies the current challenge with the given token.
+	 *
 	 * @param token the challenge response token
 	 * @return if the token was valid or not
 	 * @throws LoginFailedException when login fails
 	 * @throws RemoteServerException when server fails
 	 * @throws InvalidProtocolBufferException when the client receives an invalid message from the server
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public boolean verifyChallenge(String token)
-			throws RemoteServerException, LoginFailedException, InvalidProtocolBufferException {
+			throws RemoteServerException, CaptchaActiveException, LoginFailedException, InvalidProtocolBufferException {
 		hasChallenge = false;
 		VerifyChallengeMessage message = VerifyChallengeMessage.newBuilder().setToken(token).build();
 		AsyncServerRequest request = new AsyncServerRequest(RequestType.VERIFY_CHALLENGE, message);
@@ -501,14 +514,15 @@ public class PokemonGo {
 
 	/**
 	 * Checks for a challenge / captcha
+	 *
 	 * @return the new challenge URL, if any
 	 * @throws LoginFailedException when login fails
 	 * @throws RemoteServerException when server fails
 	 * @throws InvalidProtocolBufferException when the client receives an invalid message from the server
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public String checkChallenge()
-			throws RemoteServerException, LoginFailedException, InvalidProtocolBufferException {
-		updateChallenge(null, false);
+			throws RemoteServerException, CaptchaActiveException, LoginFailedException, InvalidProtocolBufferException {
 		CheckChallengeMessage message = CheckChallengeMessage.newBuilder().build();
 		AsyncServerRequest request = new AsyncServerRequest(RequestType.CHECK_CHALLENGE, message);
 		ByteString responseData =

--- a/library/src/main/java/com/pokegoapi/api/gym/Battle.java
+++ b/library/src/main/java/com/pokegoapi/api/gym/Battle.java
@@ -30,6 +30,7 @@ import POGOProtos.Networking.Responses.StartGymBattleResponseOuterClass.StartGym
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.pokemon.Pokemon;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.main.ServerRequest;
@@ -53,9 +54,9 @@ public class Battle {
 	/**
 	 * New battle to track the state of a battle.
 	 *
-	 * @param api  The api instance to submit requests with.
+	 * @param api The api instance to submit requests with.
 	 * @param teams The Pokemon to use for attacking in the battle.
-	 * @param gym  The Gym to fight at.
+	 * @param gym The Gym to fight at.
 	 */
 	public Battle(PokemonGo api, Pokemon[] teams, Gym gym) {
 		this.teams = teams;
@@ -71,10 +72,11 @@ public class Battle {
 	 * Start a battle.
 	 *
 	 * @return Result of the attempt to start
-	 * @throws LoginFailedException  if the login failed
+	 * @throws LoginFailedException if the login failed
 	 * @throws RemoteServerException When a buffer exception is thrown
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public Result start() throws LoginFailedException, RemoteServerException {
+	public Result start() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		Builder builder = StartGymBattleMessageOuterClass.StartGymBattleMessage.newBuilder();
 
 		for (Pokemon team : teams) {
@@ -114,10 +116,12 @@ public class Battle {
 	 *
 	 * @param times the amount of times to attack
 	 * @return Battle
-	 * @throws LoginFailedException  if the login failed
+	 * @throws LoginFailedException if the login failed
 	 * @throws RemoteServerException When a buffer exception is thrown
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public AttackGymResponse attack(int times) throws LoginFailedException, RemoteServerException {
+	public AttackGymResponse attack(int times)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 
 		ArrayList<BattleAction> actions = new ArrayList<>();
 
@@ -157,7 +161,8 @@ public class Battle {
 	 * @param index of defender(0 to gym lever)
 	 * @return Battle
 	 */
-	private PokemonDataOuterClass.PokemonData getDefender(int index) throws LoginFailedException, RemoteServerException {
+	private PokemonDataOuterClass.PokemonData getDefender(int index)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return gym.getGymMembers().get(0).getPokemonData();
 	}
 
@@ -178,7 +183,8 @@ public class Battle {
 	 *
 	 * @return AttackGymResponse
 	 */
-	private AttackGymResponse sendBlankAction() throws LoginFailedException, RemoteServerException {
+	private AttackGymResponse sendBlankAction()
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		AttackGymMessage message = AttackGymMessage
 				.newBuilder()
 				.setGymId(gym.getId())
@@ -205,7 +211,8 @@ public class Battle {
 	 * @param actions list of actions to send in this request
 	 * @return AttackGymResponse
 	 */
-	private AttackGymResponse doActions(List<BattleAction> actions) throws LoginFailedException, RemoteServerException {
+	private AttackGymResponse doActions(List<BattleAction> actions)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 
 
 		AttackGymMessage.Builder message = AttackGymMessage

--- a/library/src/main/java/com/pokegoapi/api/inventory/EggIncubator.java
+++ b/library/src/main/java/com/pokegoapi/api/inventory/EggIncubator.java
@@ -15,18 +15,18 @@
 
 package com.pokegoapi.api.inventory;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.pokegoapi.api.PokemonGo;
-import com.pokegoapi.api.pokemon.EggPokemon;
-import com.pokegoapi.exceptions.LoginFailedException;
-import com.pokegoapi.exceptions.RemoteServerException;
-import com.pokegoapi.main.ServerRequest;
-
 import POGOProtos.Inventory.EggIncubatorOuterClass;
 import POGOProtos.Inventory.EggIncubatorTypeOuterClass.EggIncubatorType;
 import POGOProtos.Networking.Requests.Messages.UseItemEggIncubatorMessageOuterClass.UseItemEggIncubatorMessage;
 import POGOProtos.Networking.Requests.RequestTypeOuterClass;
 import POGOProtos.Networking.Responses.UseItemEggIncubatorResponseOuterClass.UseItemEggIncubatorResponse;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.pokegoapi.api.PokemonGo;
+import com.pokegoapi.api.pokemon.EggPokemon;
+import com.pokegoapi.exceptions.CaptchaActiveException;
+import com.pokegoapi.exceptions.LoginFailedException;
+import com.pokegoapi.exceptions.RemoteServerException;
+import com.pokegoapi.main.ServerRequest;
 
 public class EggIncubator {
 	private final EggIncubatorOuterClass.EggIncubator proto;
@@ -59,9 +59,10 @@ public class EggIncubator {
 	 * @return status of putting egg in incubator
 	 * @throws RemoteServerException the remote server exception
 	 * @throws LoginFailedException  the login failed exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public UseItemEggIncubatorResponse.Result hatchEgg(EggPokemon egg)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 
 		UseItemEggIncubatorMessage reqMsg = UseItemEggIncubatorMessage.newBuilder()
 				.setItemId(proto.getId())

--- a/library/src/main/java/com/pokegoapi/api/inventory/EggIncubator.java
+++ b/library/src/main/java/com/pokegoapi/api/inventory/EggIncubator.java
@@ -165,4 +165,9 @@ public class EggIncubator {
 	public boolean isInUse() {
 		return getKmTarget() > api.getPlayerProfile().getStats().getKmWalked();
 	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return obj instanceof EggIncubator && ((EggIncubator) obj).getId().equals(getId());
+	}
 }

--- a/library/src/main/java/com/pokegoapi/api/inventory/Hatchery.java
+++ b/library/src/main/java/com/pokegoapi/api/inventory/Hatchery.java
@@ -23,6 +23,7 @@ import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.listener.PokemonListener;
 import com.pokegoapi.api.pokemon.EggPokemon;
 import com.pokegoapi.api.pokemon.HatchedEgg;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.main.ServerRequest;
@@ -103,10 +104,13 @@ public class Hatchery {
 	 * @return list of hatched eggs
 	 * @throws RemoteServerException e
 	 * @throws LoginFailedException  e
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
+	 *
 	 * @deprecated Use getHatchedEggs()
 	 */
 	@Deprecated
-	public List<HatchedEgg> queryHatchedEggs() throws RemoteServerException, LoginFailedException {
+	public List<HatchedEgg> queryHatchedEggs()
+			throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		GetHatchedEggsMessage msg = GetHatchedEggsMessage.newBuilder().build();
 		ServerRequest serverRequest = new ServerRequest(RequestType.GET_HATCHED_EGGS, msg);
 		api.getRequestHandler().sendServerRequests(serverRequest);

--- a/library/src/main/java/com/pokegoapi/api/inventory/Inventories.java
+++ b/library/src/main/java/com/pokegoapi/api/inventory/Inventories.java
@@ -29,6 +29,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.pokemon.EggPokemon;
 import com.pokegoapi.api.pokemon.Pokemon;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.main.ServerRequest;
@@ -75,8 +76,9 @@ public class Inventories {
 	 *
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void updateInventories() throws LoginFailedException, RemoteServerException {
+	public void updateInventories() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		updateInventories(false);
 	}
 
@@ -86,8 +88,10 @@ public class Inventories {
 	 * @param forceUpdate For a full update if true
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void updateInventories(boolean forceUpdate) throws LoginFailedException, RemoteServerException {
+	public void updateInventories(boolean forceUpdate)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		if (forceUpdate) {
 			lastInventoryUpdate = 0;
 			itemBag.reset();

--- a/library/src/main/java/com/pokegoapi/api/inventory/Inventories.java
+++ b/library/src/main/java/com/pokegoapi/api/inventory/Inventories.java
@@ -166,7 +166,9 @@ public class Inventories {
 
 			if (itemData.hasEggIncubators()) {
 				for (EggIncubatorOuterClass.EggIncubator incubator : itemData.getEggIncubators().getEggIncubatorList()) {
-					incubators.add(new EggIncubator(api, incubator));
+					EggIncubator eggIncubator = new EggIncubator(api, incubator);
+					incubators.remove(eggIncubator);
+					incubators.add(eggIncubator);
 				}
 			}
 

--- a/library/src/main/java/com/pokegoapi/api/inventory/ItemBag.java
+++ b/library/src/main/java/com/pokegoapi/api/inventory/ItemBag.java
@@ -27,6 +27,7 @@ import POGOProtos.Networking.Responses.UseIncenseResponseOuterClass.UseIncenseRe
 import POGOProtos.Networking.Responses.UseItemXpBoostResponseOuterClass.UseItemXpBoostResponse;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.pokegoapi.api.PokemonGo;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.main.ServerRequest;
@@ -60,13 +61,15 @@ public class ItemBag {
 	/**
 	 * Discards the given item.
 	 *
-	 * @param id       the id
+	 * @param id the id
 	 * @param quantity the quantity
 	 * @return the result
 	 * @throws RemoteServerException the remote server exception
-	 * @throws LoginFailedException  the login failed exception
+	 * @throws LoginFailedException the login failed exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public Result removeItem(ItemId id, int quantity) throws RemoteServerException, LoginFailedException {
+	public Result removeItem(ItemId id, int quantity)
+			throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		Item item = getItem(id);
 		if (item.getCount() < quantity) {
 			throw new IllegalArgumentException("You cannot remove more quantity than you have");
@@ -147,9 +150,10 @@ public class ItemBag {
 	 *
 	 * @param type type of item
 	 * @throws RemoteServerException the remote server exception
-	 * @throws LoginFailedException  the login failed exception
+	 * @throws LoginFailedException the login failed exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void useItem(ItemId type) throws RemoteServerException, LoginFailedException {
+	public void useItem(ItemId type) throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		if (type == ItemId.UNRECOGNIZED) {
 			throw new IllegalArgumentException("You cannot use item for UNRECOGNIZED");
 		}
@@ -171,9 +175,10 @@ public class ItemBag {
 	 *
 	 * @param type type of item
 	 * @throws RemoteServerException the remote server exception
-	 * @throws LoginFailedException  the login failed exception
+	 * @throws LoginFailedException the login failed exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void useIncense(ItemId type) throws RemoteServerException, LoginFailedException {
+	public void useIncense(ItemId type) throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		UseIncenseMessage useIncenseMessage =
 				UseIncenseMessage.newBuilder()
 						.setIncenseType(type)
@@ -197,9 +202,10 @@ public class ItemBag {
 	 * use an item with itemID
 	 *
 	 * @throws RemoteServerException the remote server exception
-	 * @throws LoginFailedException  the login failed exception
+	 * @throws LoginFailedException the login failed exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void useIncense() throws RemoteServerException, LoginFailedException {
+	public void useIncense() throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		useIncense(ItemId.ITEM_INCENSE_ORDINARY);
 	}
 
@@ -208,9 +214,11 @@ public class ItemBag {
 	 *
 	 * @return the xp boost response
 	 * @throws RemoteServerException the remote server exception
-	 * @throws LoginFailedException  the login failed exception
+	 * @throws LoginFailedException the login failed exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public UseItemXpBoostResponse useLuckyEgg() throws RemoteServerException, LoginFailedException {
+	public UseItemXpBoostResponse useLuckyEgg()
+			throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		UseItemXpBoostMessage xpMsg = UseItemXpBoostMessage
 				.newBuilder()
 				.setItemId(ItemId.ITEM_LUCKY_EGG)

--- a/library/src/main/java/com/pokegoapi/api/map/Map.java
+++ b/library/src/main/java/com/pokegoapi/api/map/Map.java
@@ -47,6 +47,7 @@ import com.pokegoapi.api.map.fort.Pokestop;
 import com.pokegoapi.api.map.pokemon.CatchablePokemon;
 import com.pokegoapi.api.map.pokemon.NearbyPokemon;
 import com.pokegoapi.exceptions.AsyncRemoteServerException;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.google.common.geometry.MutableInteger;
@@ -140,8 +141,10 @@ public class Map {
 	 * @return a List of CatchablePokemon at your current location
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public List<CatchablePokemon> getCatchablePokemon() throws LoginFailedException, RemoteServerException {
+	public List<CatchablePokemon> getCatchablePokemon()
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(getCatchablePokemonAsync());
 	}
 
@@ -151,9 +154,10 @@ public class Map {
 	 * @return the catchable pokemon sort
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public java.util.Map<Double, CatchablePokemon> getCatchablePokemonSort()
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		MapUtil<CatchablePokemon> util = new MapUtil<>();
 		return util.sortItems(getCatchablePokemon(), api);
 	}
@@ -183,8 +187,10 @@ public class Map {
 	 * @return a List of NearbyPokemon at your current location
 	 * @throws LoginFailedException  if the login failed
 	 * @throws RemoteServerException When a buffer exception is thrown
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public List<NearbyPokemon> getNearbyPokemon() throws LoginFailedException, RemoteServerException {
+	public List<NearbyPokemon> getNearbyPokemon()
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(getNearbyPokemonAsync());
 	}
 
@@ -214,8 +220,9 @@ public class Map {
 	 * @return list of spawn points
 	 * @throws LoginFailedException  if the login failed
 	 * @throws RemoteServerException When a buffer exception is thrown
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public List<Point> getSpawnPoints() throws LoginFailedException, RemoteServerException {
+	public List<Point> getSpawnPoints() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(getSpawnPointsAsync());
 	}
 
@@ -245,8 +252,9 @@ public class Map {
 	 * @return List of gyms
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public List<Gym> getGyms() throws LoginFailedException, RemoteServerException {
+	public List<Gym> getGyms() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(getGymsAsync());
 	}
 
@@ -256,8 +264,10 @@ public class Map {
 	 * @return the gym sort
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public java.util.Map<Double, Gym> getGymSort() throws LoginFailedException, RemoteServerException {
+	public java.util.Map<Double, Gym> getGymSort()
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		MapUtil<Gym> util = new MapUtil<>();
 		return util.sortItems(getGyms(), api);
 	}
@@ -286,8 +296,10 @@ public class Map {
 	 * @return list of spawn points
 	 * @throws LoginFailedException  if the login failed
 	 * @throws RemoteServerException When a buffer exception is thrown
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public List<Point> getDecimatedSpawnPoints() throws LoginFailedException, RemoteServerException {
+	public List<Point> getDecimatedSpawnPoints()
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(getDecimatedSpawnPointsAsync());
 	}
 
@@ -298,8 +310,10 @@ public class Map {
 	 * @return the decimated spawn points sort
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public java.util.Map<Double, Point> getDecimatedSpawnPointsSort() throws LoginFailedException, RemoteServerException {
+	public java.util.Map<Double, Point> getDecimatedSpawnPointsSort()
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		MapUtil<Point> util = new MapUtil<>();
 		return util.sortItems(getDecimatedSpawnPoints(), api);
 	}
@@ -396,8 +410,9 @@ public class Map {
 	 * @return MapObjects at your current location
 	 * @throws LoginFailedException  if the login failed
 	 * @throws RemoteServerException When a buffer exception is thrown
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public MapObjects getMapObjects() throws LoginFailedException, RemoteServerException {
+	public MapObjects getMapObjects() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(getMapObjectsAsync());
 	}
 
@@ -408,8 +423,10 @@ public class Map {
 	 * @return MapObjects at your current location
 	 * @throws LoginFailedException  If login fails.
 	 * @throws RemoteServerException If request errors occurred.
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public MapObjects getMapObjects(int width) throws LoginFailedException, RemoteServerException {
+	public MapObjects getMapObjects(int width)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(getMapObjectsAsync(width));
 	}
 
@@ -421,10 +438,11 @@ public class Map {
 	 * @return MapObjects in the given cells
 	 * @throws LoginFailedException  if the login failed
 	 * @throws RemoteServerException When a buffer exception is thrown
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	@Deprecated
 	public MapObjects getMapObjects(double latitude, double longitude)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return getMapObjects(latitude, longitude, cellWidth);
 	}
 
@@ -437,10 +455,11 @@ public class Map {
 	 * @return MapObjects in the given cells
 	 * @throws LoginFailedException  if the login failed
 	 * @throws RemoteServerException When a buffer exception is thrown
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	@Deprecated
 	public MapObjects getMapObjects(List<Long> cellIds, double latitude, double longitude)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return getMapObjects(cellIds, latitude, longitude, 0);
 	}
 
@@ -453,10 +472,11 @@ public class Map {
 	 * @return MapObjects in the given cells
 	 * @throws LoginFailedException  if the login failed
 	 * @throws RemoteServerException When a buffer exception is thrown
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	@Deprecated
 	public MapObjects getMapObjects(double latitude, double longitude, int width)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return getMapObjects(getCellIds(latitude, longitude, width), latitude, longitude);
 	}
 
@@ -470,10 +490,11 @@ public class Map {
 	 * @return MapObjects in the given cells
 	 * @throws LoginFailedException  if the login failed
 	 * @throws RemoteServerException When a buffer exception is thrown
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	@Deprecated
 	public MapObjects getMapObjects(List<Long> cellIds, double latitude, double longitude, double altitude)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		api.setLatitude(latitude);
 		api.setLongitude(longitude);
 		api.setAltitude(altitude);
@@ -487,8 +508,10 @@ public class Map {
 	 * @return MapObjects in the given cells
 	 * @throws LoginFailedException  if the login failed
 	 * @throws RemoteServerException When a buffer exception is thrown
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public MapObjects getMapObjects(List<Long> cellIds) throws LoginFailedException, RemoteServerException {
+	public MapObjects getMapObjects(List<Long> cellIds)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(getMapObjectsAsync(cellIds));
 	}
 
@@ -564,9 +587,10 @@ public class Map {
 	 * @return the fort details
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public FortDetails getFortDetails(String id, double lon, double lat)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(getFortDetailsAsync(id, lon, lat));
 	}
 
@@ -577,9 +601,11 @@ public class Map {
 	 * @return the fort search response
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	@Deprecated
-	public FortSearchResponse searchFort(FortData fortData) throws LoginFailedException, RemoteServerException {
+	public FortSearchResponse searchFort(FortData fortData)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		FortSearchMessage reqMsg = FortSearchMessage.newBuilder()
 				.setFortId(fortData.getId())
 				.setFortLatitude(fortData.getLatitude())
@@ -607,10 +633,11 @@ public class Map {
 	 * @return the encounter response
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	@Deprecated
 	public EncounterResponse encounterPokemon(MapPokemon catchablePokemon)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 
 		EncounterMessageOuterClass.EncounterMessage reqMsg = EncounterMessageOuterClass.EncounterMessage.newBuilder()
 				.setEncounterId(catchablePokemon.getEncounterId())
@@ -641,6 +668,7 @@ public class Map {
 	 * @return the catch pokemon response
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	@Deprecated
 	public CatchPokemonResponse catchPokemon(
@@ -649,7 +677,7 @@ public class Map {
 			double normalizedReticleSize,
 			double spinModifier,
 			ItemId pokeball)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 
 		CatchPokemonMessage reqMsg = CatchPokemonMessage.newBuilder()
 				.setEncounterId(catchablePokemon.getEncounterId())

--- a/library/src/main/java/com/pokegoapi/api/map/fort/Pokestop.java
+++ b/library/src/main/java/com/pokegoapi/api/map/fort/Pokestop.java
@@ -30,6 +30,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.listener.PokestopListener;
 import com.pokegoapi.exceptions.AsyncRemoteServerException;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.google.common.geometry.S2LatLng;
@@ -171,8 +172,9 @@ public class Pokestop {
 	 * @return PokestopLootResult
 	 * @throws LoginFailedException  if login failed
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public PokestopLootResult loot() throws LoginFailedException, RemoteServerException {
+	public PokestopLootResult loot() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(lootAsync());
 	}
 
@@ -210,8 +212,10 @@ public class Pokestop {
 	 * @param item the modifier to add to this pokestop
 	 * @throws LoginFailedException  if login failed
 	 * @throws RemoteServerException if the server failed to respond or the modifier could not be added to this pokestop
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void addModifier(ItemIdOuterClass.ItemId item) throws LoginFailedException, RemoteServerException {
+	public void addModifier(ItemIdOuterClass.ItemId item)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		AsyncHelper.toBlocking(addModifierAsync(item));
 	}
 
@@ -249,8 +253,9 @@ public class Pokestop {
 	 * @return FortDetails
 	 * @throws LoginFailedException  if login failed
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public FortDetails getDetails() throws LoginFailedException, RemoteServerException {
+	public FortDetails getDetails() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(getDetailsAsync());
 	}
 
@@ -272,7 +277,7 @@ public class Pokestop {
 	public boolean hasLure() {
 		try {
 			return hasLure(false);
-		} catch (LoginFailedException | RemoteServerException e) {
+		} catch (LoginFailedException | RemoteServerException | CaptchaActiveException e) {
 			// No need
 		}
 
@@ -286,8 +291,10 @@ public class Pokestop {
 	 * @return lure status
 	 * @throws LoginFailedException  If login failed.
 	 * @throws RemoteServerException If server communications failed.
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public boolean hasLure(boolean updateFortDetails) throws LoginFailedException, RemoteServerException {
+	public boolean hasLure(boolean updateFortDetails)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		if (updateFortDetails) {
 			List<FortModifierOuterClass.FortModifier> modifiers = getDetails().getModifier();
 			for (FortModifierOuterClass.FortModifier modifier : modifiers) {

--- a/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
@@ -43,8 +43,10 @@ import com.pokegoapi.api.map.pokemon.encounter.EncounterResult;
 import com.pokegoapi.api.map.pokemon.encounter.NormalEncounterResult;
 import com.pokegoapi.api.settings.AsyncCatchOptions;
 import com.pokegoapi.api.settings.CatchOptions;
+import com.pokegoapi.exceptions.AsyncCaptchaActiveException;
 import com.pokegoapi.exceptions.AsyncLoginFailedException;
 import com.pokegoapi.exceptions.AsyncRemoteServerException;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.EncounterFailedException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.NoSuchItemException;
@@ -156,8 +158,10 @@ public class CatchablePokemon implements MapPoint {
 	 * @return the encounter result
 	 * @throws LoginFailedException the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public EncounterResult encounterPokemon() throws LoginFailedException, RemoteServerException {
+	public EncounterResult encounterPokemon()
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(encounterPokemonAsync());
 	}
 
@@ -221,8 +225,9 @@ public class CatchablePokemon implements MapPoint {
 	 * @return the encounter result
 	 * @throws LoginFailedException the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public EncounterResult encounterNormalPokemon() throws LoginFailedException,
+	public EncounterResult encounterNormalPokemon() throws LoginFailedException, CaptchaActiveException,
 			RemoteServerException {
 		return AsyncHelper.toBlocking(encounterNormalPokemonAsync());
 	}
@@ -271,9 +276,10 @@ public class CatchablePokemon implements MapPoint {
 	 * @return CatchResult
 	 * @throws LoginFailedException if failed to login
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 * @throws NoSuchItemException the no such item exception
 	 */
-	public CatchResult catchPokemon(CatchOptions options) throws LoginFailedException,
+	public CatchResult catchPokemon(CatchOptions options) throws LoginFailedException, CaptchaActiveException,
 			RemoteServerException, NoSuchItemException {
 		if (options == null) {
 			options = new CatchOptions(api);
@@ -297,10 +303,11 @@ public class CatchablePokemon implements MapPoint {
 	 * @throws LoginFailedException the login failed exception
 	 * @throws RemoteServerException the remote server exception
 	 * @throws NoSuchItemException the no such item exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 * @throws EncounterFailedException the encounter failed exception
 	 */
 	public CatchResult catchPokemon(EncounterResult encounter, CatchOptions options)
-			throws LoginFailedException, RemoteServerException,
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException,
 			NoSuchItemException, EncounterFailedException {
 
 		if (!encounter.wasSuccessful()) throw new EncounterFailedException();
@@ -326,8 +333,9 @@ public class CatchablePokemon implements MapPoint {
 	 * @throws LoginFailedException if failed to login
 	 * @throws RemoteServerException if the server failed to respond
 	 * @throws NoSuchItemException the no such item exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public CatchResult catchPokemon() throws LoginFailedException,
+	public CatchResult catchPokemon() throws LoginFailedException, CaptchaActiveException,
 			RemoteServerException, NoSuchItemException {
 
 		return catchPokemon(new CatchOptions(api));
@@ -344,10 +352,12 @@ public class CatchablePokemon implements MapPoint {
 	 * @return CatchResult of resulted try to catch pokemon
 	 * @throws LoginFailedException if failed to login
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public CatchResult catchPokemon(double normalizedHitPosition,
 									double normalizedReticleSize, double spinModifier, Pokeball type,
-									int amount) throws LoginFailedException, RemoteServerException {
+									int amount)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 
 		return catchPokemon(normalizedHitPosition, normalizedReticleSize, spinModifier, type, amount, 0);
 	}
@@ -360,9 +370,10 @@ public class CatchablePokemon implements MapPoint {
 	 * @throws LoginFailedException if failed to login
 	 * @throws RemoteServerException if the server failed to respond
 	 * @throws NoSuchItemException the no such item exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public Observable<CatchResult> catchPokemon(AsyncCatchOptions options)
-			throws LoginFailedException, RemoteServerException, NoSuchItemException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException, NoSuchItemException {
 		if (options != null) {
 			if (options.getUseRazzBerry() != 0) {
 				final AsyncCatchOptions asyncOptions = options;
@@ -401,10 +412,11 @@ public class CatchablePokemon implements MapPoint {
 	 * @throws RemoteServerException the remote server exception
 	 * @throws NoSuchItemException the no such item exception
 	 * @throws EncounterFailedException the encounter failed exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public Observable<CatchResult> catchPokemon(EncounterResult encounter,
 												AsyncCatchOptions options)
-			throws LoginFailedException, RemoteServerException,
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException,
 			NoSuchItemException, EncounterFailedException {
 
 		if (!encounter.wasSuccessful()) throw new EncounterFailedException();
@@ -448,11 +460,12 @@ public class CatchablePokemon implements MapPoint {
 	 * @return CatchResult of resulted try to catch pokemon
 	 * @throws LoginFailedException if failed to login
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public CatchResult catchPokemon(double normalizedHitPosition,
 									double normalizedReticleSize, double spinModifier, Pokeball type,
 									int amount, int razberriesLimit)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 
 		Item razzberriesInventory = api.getInventories().getItemBag().getItem(ItemId.ITEM_RAZZ_BERRY);
 		int razzberriesCountInventory = razzberriesInventory.getCount();
@@ -576,6 +589,8 @@ public class CatchablePokemon implements MapPoint {
 					throw new AsyncRemoteServerException(e);
 				} catch (LoginFailedException e) {
 					throw new AsyncLoginFailedException(e);
+				} catch (CaptchaActiveException e) {
+					throw new AsyncCaptchaActiveException(e);
 				}
 			}
 		});
@@ -623,8 +638,10 @@ public class CatchablePokemon implements MapPoint {
 	 * @return CatchItemResult info about the new modifiers about the pokemon (can move, item capture multi) eg
 	 * @throws LoginFailedException if failed to login
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public CatchItemResult useItem(ItemId item) throws LoginFailedException, RemoteServerException {
+	public CatchItemResult useItem(ItemId item)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(useItemAsync(item));
 	}
 

--- a/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
@@ -47,7 +47,6 @@ import com.pokegoapi.exceptions.AsyncCaptchaActiveException;
 import com.pokegoapi.exceptions.AsyncLoginFailedException;
 import com.pokegoapi.exceptions.AsyncRemoteServerException;
 import com.pokegoapi.exceptions.CaptchaActiveException;
-import com.pokegoapi.exceptions.EncounterFailedException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.NoSuchItemException;
 import com.pokegoapi.exceptions.RemoteServerException;
@@ -304,13 +303,13 @@ public class CatchablePokemon implements MapPoint {
 	 * @throws RemoteServerException the remote server exception
 	 * @throws NoSuchItemException the no such item exception
 	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
-	 * @throws EncounterFailedException the encounter failed exception
+	 * @throws CaptchaActiveException the encounter failed exception
 	 */
 	public CatchResult catchPokemon(EncounterResult encounter, CatchOptions options)
 			throws LoginFailedException, CaptchaActiveException, RemoteServerException,
-			NoSuchItemException, EncounterFailedException {
+			NoSuchItemException, CaptchaActiveException {
 
-		if (!encounter.wasSuccessful()) throw new EncounterFailedException();
+		if (!encounter.wasSuccessful()) throw new RemoteServerException();
 		double probability = encounter.getCaptureProbability().getCaptureProbability(0);
 
 		if (options == null) {
@@ -411,15 +410,15 @@ public class CatchablePokemon implements MapPoint {
 	 * @throws LoginFailedException the login failed exception
 	 * @throws RemoteServerException the remote server exception
 	 * @throws NoSuchItemException the no such item exception
-	 * @throws EncounterFailedException the encounter failed exception
+	 * @throws CaptchaActiveException the encounter failed exception
 	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public Observable<CatchResult> catchPokemon(EncounterResult encounter,
 												AsyncCatchOptions options)
 			throws LoginFailedException, CaptchaActiveException, RemoteServerException,
-			NoSuchItemException, EncounterFailedException {
+			NoSuchItemException, CaptchaActiveException {
 
-		if (!encounter.wasSuccessful()) throw new EncounterFailedException();
+		if (!encounter.wasSuccessful()) throw new RemoteServerException();
 
 		if (options != null) {
 			if (options.getUseRazzBerry() != 0) {
@@ -583,14 +582,13 @@ public class CatchablePokemon implements MapPoint {
 					if (response.getStatus() == CatchStatus.CATCH_ESCAPE) {
 						api.getInventories().updateInventories();
 					}
-					CatchResult res = new CatchResult(response);
-					return res;
+					return new CatchResult(response);
 				} catch (RemoteServerException e) {
 					throw new AsyncRemoteServerException(e);
 				} catch (LoginFailedException e) {
 					throw new AsyncLoginFailedException(e);
 				} catch (CaptchaActiveException e) {
-					throw new AsyncCaptchaActiveException(e);
+					throw new AsyncCaptchaActiveException(e, e.getCaptcha());
 				}
 			}
 		});

--- a/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/map/pokemon/CatchablePokemon.java
@@ -47,6 +47,7 @@ import com.pokegoapi.exceptions.AsyncCaptchaActiveException;
 import com.pokegoapi.exceptions.AsyncLoginFailedException;
 import com.pokegoapi.exceptions.AsyncRemoteServerException;
 import com.pokegoapi.exceptions.CaptchaActiveException;
+import com.pokegoapi.exceptions.EncounterFailedException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.NoSuchItemException;
 import com.pokegoapi.exceptions.RemoteServerException;
@@ -303,13 +304,13 @@ public class CatchablePokemon implements MapPoint {
 	 * @throws RemoteServerException the remote server exception
 	 * @throws NoSuchItemException the no such item exception
 	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
-	 * @throws CaptchaActiveException the encounter failed exception
+	 * @throws EncounterFailedException the encounter failed exception
 	 */
 	public CatchResult catchPokemon(EncounterResult encounter, CatchOptions options)
-			throws LoginFailedException, CaptchaActiveException, RemoteServerException,
+			throws LoginFailedException, EncounterFailedException, RemoteServerException,
 			NoSuchItemException, CaptchaActiveException {
 
-		if (!encounter.wasSuccessful()) throw new RemoteServerException();
+		if (!encounter.wasSuccessful()) throw new EncounterFailedException();
 		double probability = encounter.getCaptureProbability().getCaptureProbability(0);
 
 		if (options == null) {
@@ -415,10 +416,10 @@ public class CatchablePokemon implements MapPoint {
 	 */
 	public Observable<CatchResult> catchPokemon(EncounterResult encounter,
 												AsyncCatchOptions options)
-			throws LoginFailedException, CaptchaActiveException, RemoteServerException,
+			throws LoginFailedException, EncounterFailedException, RemoteServerException,
 			NoSuchItemException, CaptchaActiveException {
 
-		if (!encounter.wasSuccessful()) throw new RemoteServerException();
+		if (!encounter.wasSuccessful()) throw new EncounterFailedException();
 
 		if (options != null) {
 			if (options.getUseRazzBerry() != 0) {

--- a/library/src/main/java/com/pokegoapi/api/player/PlayerProfile.java
+++ b/library/src/main/java/com/pokegoapi/api/player/PlayerProfile.java
@@ -47,6 +47,7 @@ import com.pokegoapi.api.inventory.ItemBag;
 import com.pokegoapi.api.inventory.Stats;
 import com.pokegoapi.api.listener.TutorialListener;
 import com.pokegoapi.api.pokemon.StarterPokemon;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.InvalidCurrencyException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
@@ -79,8 +80,9 @@ public class PlayerProfile {
 	 * @param api the api
 	 * @throws LoginFailedException  when the auth is invalid
 	 * @throws RemoteServerException when the server is down/having issues
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public PlayerProfile(PokemonGo api) throws LoginFailedException, RemoteServerException {
+	public PlayerProfile(PokemonGo api) throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		this.api = api;
 		this.playerLocale = new PlayerLocale();
 
@@ -94,8 +96,9 @@ public class PlayerProfile {
 	 *
 	 * @throws LoginFailedException  when the auth is invalid
 	 * @throws RemoteServerException when the server is down/having issues
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void updateProfile() throws RemoteServerException, LoginFailedException {
+	public void updateProfile() throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		GetPlayerMessage getPlayerReqMsg = GetPlayerMessage.newBuilder()
 				.setPlayerLocale(playerLocale.getPlayerLocale())
 				.build();
@@ -154,9 +157,11 @@ public class PlayerProfile {
 	 * @return a PlayerLevelUpRewards object containing information about the items rewarded and unlocked for this level
 	 * @throws LoginFailedException  when the auth is invalid
 	 * @throws RemoteServerException when the server is down/having issues
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 * @see PlayerLevelUpRewards
 	 */
-	public PlayerLevelUpRewards acceptLevelUpRewards(int level) throws RemoteServerException, LoginFailedException {
+	public PlayerLevelUpRewards acceptLevelUpRewards(int level)
+			throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		// Check if we even have achieved this level yet
 		if (level > stats.getLevel()) {
 			return new PlayerLevelUpRewards(PlayerLevelUpRewards.Status.NOT_UNLOCKED_YET);
@@ -202,8 +207,9 @@ public class PlayerProfile {
 	 *
 	 * @throws LoginFailedException  when the auth is invalid
 	 * @throws RemoteServerException When a buffer exception is thrown
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void checkAndEquipBadges() throws LoginFailedException, RemoteServerException {
+	public void checkAndEquipBadges() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		CheckAwardedBadgesMessage msg = CheckAwardedBadgesMessage.newBuilder().build();
 		ServerRequest serverRequest = new ServerRequest(RequestType.CHECK_AWARDED_BADGES, msg);
 		api.getRequestHandler().sendServerRequests(serverRequest);
@@ -316,8 +322,9 @@ public class PlayerProfile {
 	 *
 	 * @throws LoginFailedException  when the auth is invalid
 	 * @throws RemoteServerException when the server is down/having issues
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void activateAccount() throws LoginFailedException, RemoteServerException {
+	public void activateAccount() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		markTutorial(TutorialStateOuterClass.TutorialState.LEGAL_SCREEN);
 	}
 
@@ -326,8 +333,9 @@ public class PlayerProfile {
 	 *
 	 * @throws LoginFailedException  when the auth is invalid
 	 * @throws RemoteServerException when the server is down/having issues
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void setupAvatar() throws LoginFailedException, RemoteServerException {
+	public void setupAvatar() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		SecureRandom random = new SecureRandom();
 
 		Gender gender = random.nextInt(100) % 2 == 0 ? Gender.FEMALE : Gender.MALE;
@@ -381,8 +389,9 @@ public class PlayerProfile {
 	 *
 	 * @throws LoginFailedException  when the auth is invalid
 	 * @throws RemoteServerException when the server is down/having issues
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void encounterTutorialComplete() throws LoginFailedException, RemoteServerException {
+	public void encounterTutorialComplete() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		StarterPokemon starter = StarterPokemon.random();
 
 		List<TutorialListener> listeners = api.getListeners(TutorialListener.class);
@@ -434,8 +443,9 @@ public class PlayerProfile {
 	 *
 	 * @throws LoginFailedException  when the auth is invalid
 	 * @throws RemoteServerException when the server is down/having issues
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void claimCodeName() throws LoginFailedException, RemoteServerException {
+	public void claimCodeName() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		claimCodeName(null);
 	}
 
@@ -445,8 +455,10 @@ public class PlayerProfile {
 	 * @param lastFailure the last name used that was already taken; null for first try.
 	 * @throws LoginFailedException  when the auth is invalid
 	 * @throws RemoteServerException when the server is down/having issues
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void claimCodeName(String lastFailure) throws LoginFailedException, RemoteServerException {
+	public void claimCodeName(String lastFailure)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		String name = randomCodenameGenerator();
 
 		List<TutorialListener> listeners = api.getListeners(TutorialListener.class);
@@ -513,14 +525,15 @@ public class PlayerProfile {
 	 *
 	 * @throws LoginFailedException  when the auth is invalid
 	 * @throws RemoteServerException when the server is down/having issues
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public void firstTimeExperienceComplete()
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		markTutorial(TutorialStateOuterClass.TutorialState.FIRST_TIME_EXPERIENCE_COMPLETE);
 	}
 
 	private void markTutorial(TutorialStateOuterClass.TutorialState state)
-				throws LoginFailedException, RemoteServerException {
+				throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		final MarkTutorialCompleteMessage tutorialMessage = MarkTutorialCompleteMessage.newBuilder()
 				.addTutorialsCompleted(state)
 				.setSendMarketingEmails(false)

--- a/library/src/main/java/com/pokegoapi/api/pokemon/EggPokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/EggPokemon.java
@@ -15,15 +15,15 @@
 
 package com.pokegoapi.api.pokemon;
 
+import POGOProtos.Data.PokemonDataOuterClass.PokemonData;
+import POGOProtos.Networking.Responses.UseItemEggIncubatorResponseOuterClass.UseItemEggIncubatorResponse;
 import com.annimon.stream.Stream;
 import com.annimon.stream.function.Predicate;
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.inventory.EggIncubator;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
-
-import POGOProtos.Data.PokemonDataOuterClass.PokemonData;
-import POGOProtos.Networking.Responses.UseItemEggIncubatorResponseOuterClass.UseItemEggIncubatorResponse;
 import lombok.Setter;
 
 /**
@@ -45,9 +45,10 @@ public class EggPokemon {
 	 * @return status of putting egg in incubator
 	 * @throws LoginFailedException  if failed to login
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public UseItemEggIncubatorResponse.Result incubate(EggIncubator incubator)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		if (incubator.isInUse()) {
 			throw new IllegalArgumentException("Incubator already used");
 		}

--- a/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
@@ -15,20 +15,6 @@
 
 package com.pokegoapi.api.pokemon;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.pokegoapi.api.PokemonGo;
-import com.pokegoapi.api.inventory.Item;
-import com.pokegoapi.api.map.pokemon.EvolutionResult;
-import com.pokegoapi.api.player.PlayerProfile;
-import com.pokegoapi.exceptions.AsyncRemoteServerException;
-import com.pokegoapi.exceptions.LoginFailedException;
-import com.pokegoapi.exceptions.NoSuchItemException;
-import com.pokegoapi.exceptions.RemoteServerException;
-import com.pokegoapi.main.AsyncServerRequest;
-import com.pokegoapi.main.ServerRequest;
-import com.pokegoapi.util.AsyncHelper;
-
 import POGOProtos.Data.PokemonDataOuterClass.PokemonData;
 import POGOProtos.Inventory.Item.ItemIdOuterClass.ItemId;
 import POGOProtos.Networking.Requests.Messages.EvolvePokemonMessageOuterClass.EvolvePokemonMessage;
@@ -47,6 +33,20 @@ import POGOProtos.Networking.Responses.SetFavoritePokemonResponseOuterClass.SetF
 import POGOProtos.Networking.Responses.UpgradePokemonResponseOuterClass.UpgradePokemonResponse;
 import POGOProtos.Networking.Responses.UseItemPotionResponseOuterClass.UseItemPotionResponse;
 import POGOProtos.Networking.Responses.UseItemReviveResponseOuterClass.UseItemReviveResponse;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.pokegoapi.api.PokemonGo;
+import com.pokegoapi.api.inventory.Item;
+import com.pokegoapi.api.map.pokemon.EvolutionResult;
+import com.pokegoapi.api.player.PlayerProfile;
+import com.pokegoapi.exceptions.AsyncRemoteServerException;
+import com.pokegoapi.exceptions.CaptchaActiveException;
+import com.pokegoapi.exceptions.LoginFailedException;
+import com.pokegoapi.exceptions.NoSuchItemException;
+import com.pokegoapi.exceptions.RemoteServerException;
+import com.pokegoapi.main.AsyncServerRequest;
+import com.pokegoapi.main.ServerRequest;
+import com.pokegoapi.util.AsyncHelper;
 import lombok.Getter;
 import lombok.Setter;
 import rx.Observable;
@@ -79,8 +79,9 @@ public class Pokemon extends PokemonDetails {
 	 * @return the result
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public Result transferPokemon() throws LoginFailedException, RemoteServerException {
+	public Result transferPokemon() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		ReleasePokemonMessage reqMsg = ReleasePokemonMessage.newBuilder().setPokemonId(getId()).build();
 
 		ServerRequest serverRequest = new ServerRequest(RequestType.RELEASE_POKEMON, reqMsg);
@@ -111,9 +112,10 @@ public class Pokemon extends PokemonDetails {
 	 * @return the nickname pokemon response . result
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public NicknamePokemonResponse.Result renamePokemon(String nickname)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		NicknamePokemonMessage reqMsg = NicknamePokemonMessage.newBuilder()
 				.setPokemonId(getId())
 				.setNickname(nickname)
@@ -142,9 +144,10 @@ public class Pokemon extends PokemonDetails {
 	 * @return the SetFavoritePokemonResponse.Result
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public SetFavoritePokemonResponse.Result setFavoritePokemon(boolean markFavorite)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		SetFavoritePokemonMessage reqMsg = SetFavoritePokemonMessage.newBuilder()
 				.setPokemonId(getId())
 				.setIsFavorite(markFavorite)
@@ -207,8 +210,10 @@ public class Pokemon extends PokemonDetails {
 	 * @return The result
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public UpgradePokemonResponse.Result powerUp() throws LoginFailedException, RemoteServerException {
+	public UpgradePokemonResponse.Result powerUp()
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		return AsyncHelper.toBlocking(powerUpAsync());
 	}
 
@@ -246,8 +251,9 @@ public class Pokemon extends PokemonDetails {
 	 * @return the evolution result
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public EvolutionResult evolve() throws LoginFailedException, RemoteServerException {
+	public EvolutionResult evolve() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		EvolvePokemonMessage reqMsg = EvolvePokemonMessage.newBuilder().setPokemonId(getId()).build();
 
 		ServerRequest serverRequest = new ServerRequest(RequestType.EVOLVE_POKEMON, reqMsg);
@@ -293,9 +299,10 @@ public class Pokemon extends PokemonDetails {
 	 * @return Result, ERROR_CANNOT_USE if the requirements arent met
 	 * @throws LoginFailedException  If login failed.
 	 * @throws RemoteServerException If server communication issues occurred.
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public UseItemPotionResponse.Result heal()
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 
 		if (!isInjured())
 			return UseItemPotionResponse.Result.ERROR_CANNOT_USE;
@@ -323,9 +330,10 @@ public class Pokemon extends PokemonDetails {
 	 * @return Result, ERROR_CANNOT_USE if the requirements aren't met
 	 * @throws LoginFailedException  If login failed.
 	 * @throws RemoteServerException If server communications failed.
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public UseItemPotionResponse.Result usePotion(ItemId itemId)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 
 		Item potion = api.getInventories().getItemBag().getItem(itemId);
 		//some sanity check, to prevent wrong use of this call
@@ -356,12 +364,13 @@ public class Pokemon extends PokemonDetails {
 	/**
 	 * Revive a pokemon, using various fallbacks for revive items
 	 *
-	 * @return Result, ERROR_CANNOT_USE if the requirements arent met
+	 * @return Result, ERROR_CANNOT_USE if the requirements aren't met
 	 * @throws LoginFailedException  If login failed.
 	 * @throws RemoteServerException If server communications failed.
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public UseItemReviveResponse.Result revive()
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 
 		if (!isFainted())
 			return UseItemReviveResponse.Result.ERROR_CANNOT_USE;
@@ -380,12 +389,13 @@ public class Pokemon extends PokemonDetails {
 	 * to be revived.
 	 *
 	 * @param itemId {@link ItemId} of the Revive to use.
-	 * @return Result, ERROR_CANNOT_USE if the requirements arent met
+	 * @return Result, ERROR_CANNOT_USE if the requirements aren't met
 	 * @throws LoginFailedException  If login failed.
 	 * @throws RemoteServerException If server communications failed.
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public UseItemReviveResponse.Result useRevive(ItemId itemId)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 
 		Item item = api.getInventories().getItemBag().getItem(itemId);
 		if (!item.isRevive() || item.getCount() < 1 || !isFainted())

--- a/library/src/main/java/com/pokegoapi/api/settings/Settings.java
+++ b/library/src/main/java/com/pokegoapi/api/settings/Settings.java
@@ -1,15 +1,15 @@
 package com.pokegoapi.api.settings;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-import com.pokegoapi.api.PokemonGo;
-import com.pokegoapi.exceptions.LoginFailedException;
-import com.pokegoapi.exceptions.RemoteServerException;
-import com.pokegoapi.main.ServerRequest;
-
 import POGOProtos.Networking.Requests.Messages.DownloadSettingsMessageOuterClass;
 import POGOProtos.Networking.Requests.RequestTypeOuterClass;
 import POGOProtos.Networking.Responses.DownloadSettingsResponseOuterClass;
 import POGOProtos.Networking.Responses.DownloadSettingsResponseOuterClass.DownloadSettingsResponse;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.pokegoapi.api.PokemonGo;
+import com.pokegoapi.exceptions.CaptchaActiveException;
+import com.pokegoapi.exceptions.LoginFailedException;
+import com.pokegoapi.exceptions.RemoteServerException;
+import com.pokegoapi.main.ServerRequest;
 import lombok.Getter;
 
 /**
@@ -89,8 +89,9 @@ public class Settings {
 	 *
 	 * @throws LoginFailedException  the login failed exception
 	 * @throws RemoteServerException the remote server exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void updateSettings() throws RemoteServerException, LoginFailedException {
+	public void updateSettings() throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		DownloadSettingsMessageOuterClass.DownloadSettingsMessage msg =
 				DownloadSettingsMessageOuterClass.DownloadSettingsMessage.newBuilder().build();
 		ServerRequest serverRequest = new ServerRequest(RequestTypeOuterClass.RequestType.DOWNLOAD_SETTINGS, msg);

--- a/library/src/main/java/com/pokegoapi/auth/GoogleAutoCredentialProvider.java
+++ b/library/src/main/java/com/pokegoapi/auth/GoogleAutoCredentialProvider.java
@@ -1,12 +1,11 @@
 package com.pokegoapi.auth;
 
 import POGOProtos.Networking.Envelopes.RequestEnvelopeOuterClass.RequestEnvelope.AuthInfo;
-
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.SystemTimeImpl;
 import com.pokegoapi.util.Time;
-
 import lombok.Getter;
 import okhttp3.OkHttpClient;
 import svarzee.gps.gpsoauth.AuthToken;
@@ -41,9 +40,10 @@ public class GoogleAutoCredentialProvider extends CredentialProvider {
 	 * @param password   google password
 	 * @throws LoginFailedException  - login failed possibly due to invalid credentials
 	 * @throws RemoteServerException - some server/network failure
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public GoogleAutoCredentialProvider(OkHttpClient httpClient, String username, String password)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		this.gpsoauth = new Gpsoauth(httpClient);
 		this.username = username;
 		this.tokenInfo = login(username, password);
@@ -57,9 +57,10 @@ public class GoogleAutoCredentialProvider extends CredentialProvider {
 	 * @param time       time instance used to refresh token
 	 * @throws LoginFailedException  login failed possibly due to invalid credentials
 	 * @throws RemoteServerException some server/network failure
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public GoogleAutoCredentialProvider(OkHttpClient httpClient, String username, String password, Time time)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		this.gpsoauth = new Gpsoauth(httpClient);
 		this.username = username;
 		this.tokenInfo = login(username, password);
@@ -67,7 +68,7 @@ public class GoogleAutoCredentialProvider extends CredentialProvider {
 	}
 
 	private TokenInfo login(String username, String password)
-			throws RemoteServerException, LoginFailedException {
+			throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		try {
 			String masterToken = gpsoauth.performMasterLoginForToken(username, password, GOOGLE_LOGIN_ANDROID_ID);
 			AuthToken authToken = gpsoauth.performOAuthForToken(username, masterToken, GOOGLE_LOGIN_ANDROID_ID,
@@ -86,9 +87,10 @@ public class GoogleAutoCredentialProvider extends CredentialProvider {
 	 * @return the token info
 	 * @throws RemoteServerException login failed possibly due to invalid credentials
 	 * @throws LoginFailedException  some server/network failure
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	private TokenInfo refreshToken(String username, String refreshToken)
-			throws RemoteServerException, LoginFailedException {
+			throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		try {
 			AuthToken authToken = gpsoauth.performOAuthForToken(username, refreshToken, GOOGLE_LOGIN_ANDROID_ID,
 					GOOGLE_LOGIN_SERVICE, GOOGLE_LOGIN_APP, GOOGLE_LOGIN_CLIENT_SIG);
@@ -104,9 +106,10 @@ public class GoogleAutoCredentialProvider extends CredentialProvider {
 	 * @return token id
 	 * @throws RemoteServerException login failed possibly due to invalid credentials
 	 * @throws LoginFailedException  some server/network failure
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	@Override
-	public String getTokenId() throws RemoteServerException, LoginFailedException {
+	public String getTokenId() throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		if (isTokenIdExpired()) {
 			this.tokenInfo = refreshToken(username, tokenInfo.refreshToken);
 		}
@@ -117,9 +120,10 @@ public class GoogleAutoCredentialProvider extends CredentialProvider {
 	 * @return auth info
 	 * @throws RemoteServerException login failed possibly due to invalid credentials
 	 * @throws LoginFailedException  some server/network failure
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	@Override
-	public AuthInfo getAuthInfo() throws RemoteServerException, LoginFailedException {
+	public AuthInfo getAuthInfo() throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		AuthInfo.Builder builder = AuthInfo.newBuilder();
 		builder.setProvider("google");
 		builder.setToken(AuthInfo.JWT.newBuilder().setContents(getTokenId()).setUnknown2(59).build());

--- a/library/src/main/java/com/pokegoapi/auth/GoogleCredentialProvider.java
+++ b/library/src/main/java/com/pokegoapi/auth/GoogleCredentialProvider.java
@@ -16,12 +16,11 @@
 package com.pokegoapi.auth;
 
 import POGOProtos.Networking.Envelopes.RequestEnvelopeOuterClass.RequestEnvelope.AuthInfo;
-
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.Log;
 import com.squareup.moshi.Moshi;
-
 import lombok.Getter;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -61,9 +60,10 @@ public class GoogleCredentialProvider extends CredentialProvider {
 	 * @param refreshToken Refresh Token Persisted by user
 	 * @throws LoginFailedException  When login fails
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public GoogleCredentialProvider(OkHttpClient client, String refreshToken)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		this.client = client;
 		this.refreshToken = refreshToken;
 		onGoogleLoginOAuthCompleteListener = null;
@@ -77,10 +77,11 @@ public class GoogleCredentialProvider extends CredentialProvider {
 	 * @param client                             OkHttp client
 	 * @param onGoogleLoginOAuthCompleteListener Callback to know verification url and also persist refresh token
 	 * @throws LoginFailedException When login fails
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public GoogleCredentialProvider(OkHttpClient client,
 									OnGoogleLoginOAuthCompleteListener onGoogleLoginOAuthCompleteListener)
-			throws LoginFailedException {
+			throws LoginFailedException, CaptchaActiveException {
 		this.client = client;
 		if (onGoogleLoginOAuthCompleteListener != null) {
 			this.onGoogleLoginOAuthCompleteListener = onGoogleLoginOAuthCompleteListener;
@@ -97,8 +98,10 @@ public class GoogleCredentialProvider extends CredentialProvider {
 	 * @param refreshToken Refresh token persisted by the user after initial login
 	 * @throws LoginFailedException  If we fail to get tokenId
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void refreshToken(String refreshToken) throws LoginFailedException, RemoteServerException {
+	public void refreshToken(String refreshToken)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		HttpUrl url = HttpUrl.parse(OAUTH_TOKEN_ENDPOINT).newBuilder()
 				.addQueryParameter("client_id", CLIENT_ID)
 				.addQueryParameter("client_secret", SECRET)
@@ -140,8 +143,9 @@ public class GoogleCredentialProvider extends CredentialProvider {
 	 * Starts a login flow for google using googles device oauth endpoint.
 	 *
 	 * @throws LoginFailedException If we fail to get tokenId
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void login() throws LoginFailedException {
+	public void login() throws LoginFailedException, CaptchaActiveException {
 
 		HttpUrl url = HttpUrl.parse(OAUTH_ENDPOINT).newBuilder()
 				.addQueryParameter("client_id", CLIENT_ID)
@@ -235,7 +239,7 @@ public class GoogleCredentialProvider extends CredentialProvider {
 	}
 
 	@Override
-	public String getTokenId() throws LoginFailedException, RemoteServerException {
+	public String getTokenId() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		if (isTokenIdExpired()) {
 			refreshToken(refreshToken);
 		}
@@ -250,7 +254,7 @@ public class GoogleCredentialProvider extends CredentialProvider {
 	 * @throws RemoteServerException if the server failed to respond
 	 */
 	@Override
-	public AuthInfo getAuthInfo() throws LoginFailedException, RemoteServerException {
+	public AuthInfo getAuthInfo() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		if (isTokenIdExpired()) {
 			refreshToken(refreshToken);
 		}

--- a/library/src/main/java/com/pokegoapi/auth/GoogleUserCredentialProvider.java
+++ b/library/src/main/java/com/pokegoapi/auth/GoogleUserCredentialProvider.java
@@ -16,14 +16,13 @@
 package com.pokegoapi.auth;
 
 import POGOProtos.Networking.Envelopes.RequestEnvelopeOuterClass.RequestEnvelope.AuthInfo;
-
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.Log;
 import com.pokegoapi.util.SystemTimeImpl;
 import com.pokegoapi.util.Time;
 import com.squareup.moshi.Moshi;
-
 import lombok.Getter;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
@@ -63,9 +62,10 @@ public class GoogleUserCredentialProvider extends CredentialProvider {
 	 * @param time         a Time implementation
 	 * @throws LoginFailedException  When login fails
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public GoogleUserCredentialProvider(OkHttpClient client, String refreshToken, Time time)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		this.time = time;
 		this.client = client;
 		this.refreshToken = refreshToken;
@@ -81,9 +81,10 @@ public class GoogleUserCredentialProvider extends CredentialProvider {
 	 * @param refreshToken Refresh Token Persisted by user
 	 * @throws LoginFailedException  When login fails
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public GoogleUserCredentialProvider(OkHttpClient client, String refreshToken)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		this.time = new SystemTimeImpl();
 		this.client = client;
 		this.refreshToken = refreshToken;
@@ -99,9 +100,10 @@ public class GoogleUserCredentialProvider extends CredentialProvider {
 	 * @param time   a Time implementation
 	 * @throws LoginFailedException  When login fails
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public GoogleUserCredentialProvider(OkHttpClient client, Time time)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		this.time = time;
 		this.client = client;
 	}
@@ -112,9 +114,10 @@ public class GoogleUserCredentialProvider extends CredentialProvider {
 	 * @param client OkHttp client
 	 * @throws LoginFailedException  When login fails
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public GoogleUserCredentialProvider(OkHttpClient client)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		this.time = new SystemTimeImpl();
 		this.client = client;
 	}
@@ -126,8 +129,10 @@ public class GoogleUserCredentialProvider extends CredentialProvider {
 	 * @param refreshToken Refresh token persisted by the user after initial login
 	 * @throws LoginFailedException  If we fail to get tokenId
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void refreshToken(String refreshToken) throws LoginFailedException, RemoteServerException {
+	public void refreshToken(String refreshToken)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		HttpUrl url = HttpUrl.parse(OAUTH_TOKEN_ENDPOINT).newBuilder()
 				.addQueryParameter("client_id", CLIENT_ID)
 				.addQueryParameter("client_secret", SECRET)
@@ -173,8 +178,9 @@ public class GoogleUserCredentialProvider extends CredentialProvider {
 	 * @param authCode auth code to authenticate
 	 * @throws LoginFailedException  if failed to login
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void login(String authCode) throws LoginFailedException, RemoteServerException {
+	public void login(String authCode) throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 
 		HttpUrl url = HttpUrl.parse(OAUTH_TOKEN_ENDPOINT).newBuilder()
 				.addQueryParameter("code", authCode)
@@ -220,7 +226,7 @@ public class GoogleUserCredentialProvider extends CredentialProvider {
 	}
 
 	@Override
-	public String getTokenId() throws LoginFailedException, RemoteServerException {
+	public String getTokenId() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		if (isTokenIdExpired()) {
 			refreshToken(refreshToken);
 		}
@@ -233,9 +239,10 @@ public class GoogleUserCredentialProvider extends CredentialProvider {
 	 * @return AuthInfo object
 	 * @throws LoginFailedException  When login fails
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	@Override
-	public AuthInfo getAuthInfo() throws LoginFailedException, RemoteServerException {
+	public AuthInfo getAuthInfo() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		if (isTokenIdExpired()) {
 			refreshToken(refreshToken);
 		}

--- a/library/src/main/java/com/pokegoapi/auth/PtcCredentialProvider.java
+++ b/library/src/main/java/com/pokegoapi/auth/PtcCredentialProvider.java
@@ -15,18 +15,13 @@
 
 package com.pokegoapi.auth;
 
+import POGOProtos.Networking.Envelopes.RequestEnvelopeOuterClass.RequestEnvelope.AuthInfo;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.SystemTimeImpl;
 import com.pokegoapi.util.Time;
 import com.squareup.moshi.Moshi;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
-import POGOProtos.Networking.Envelopes.RequestEnvelopeOuterClass.RequestEnvelope.AuthInfo;
 import okhttp3.Cookie;
 import okhttp3.CookieJar;
 import okhttp3.HttpUrl;
@@ -35,6 +30,11 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 
 public class PtcCredentialProvider extends CredentialProvider {
@@ -66,9 +66,10 @@ public class PtcCredentialProvider extends CredentialProvider {
 	 * @param time     a Time implementation
 	 * @throws LoginFailedException  When login fails
 	 * @throws RemoteServerException When server fails
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public PtcCredentialProvider(OkHttpClient client, String username, String password, Time time)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		this.time = time;
 		this.username = username;
 		this.password = password;
@@ -118,9 +119,10 @@ public class PtcCredentialProvider extends CredentialProvider {
 	 * @param password password
 	 * @throws LoginFailedException  if failed to login
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	public PtcCredentialProvider(OkHttpClient client, String username, String password)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		this(client, username, password, new SystemTimeImpl());
 	}
 
@@ -132,8 +134,10 @@ public class PtcCredentialProvider extends CredentialProvider {
 	 * @param password PTC password
 	 * @throws LoginFailedException  if failed to login
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	private void login(String username, String password) throws LoginFailedException, RemoteServerException {
+	private void login(String username, String password)
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		//TODO: stop creating an okhttp client per request
 		Request get = new Request.Builder()
 				.url(LOGIN_URL)
@@ -253,7 +257,7 @@ public class PtcCredentialProvider extends CredentialProvider {
 	}
 
 	@Override
-	public String getTokenId() throws LoginFailedException, RemoteServerException {
+	public String getTokenId() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		if (isTokenIdExpired()) {
 			login(username, password);
 		}
@@ -266,9 +270,10 @@ public class PtcCredentialProvider extends CredentialProvider {
 	 * @return AuthInfo a AuthInfo proto structure to be encapsulated in server requests
 	 * @throws LoginFailedException  if failed to login
 	 * @throws RemoteServerException if the server failed to respond
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	@Override
-	public AuthInfo getAuthInfo() throws LoginFailedException, RemoteServerException {
+	public AuthInfo getAuthInfo() throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		if (isTokenIdExpired()) {
 			login(username, password);
 		}

--- a/library/src/main/java/com/pokegoapi/exceptions/AsyncCaptchaActiveException.java
+++ b/library/src/main/java/com/pokegoapi/exceptions/AsyncCaptchaActiveException.java
@@ -15,15 +15,22 @@
 
 package com.pokegoapi.exceptions;
 
+import lombok.Getter;
+
 /**
  * Exception thrown when a message is requested to send, but a captcha is currently active
  */
 public class AsyncCaptchaActiveException extends AsyncPokemonGoException {
-	public AsyncCaptchaActiveException() {
+	@Getter
+	private String captcha;
+
+	public AsyncCaptchaActiveException(String captcha) {
 		super("Captcha must be solved before sending messages!");
+		this.captcha = captcha;
 	}
 
-	public AsyncCaptchaActiveException(Exception exception) {
+	public AsyncCaptchaActiveException(Exception exception, String captcha) {
 		super("Captcha must be solved before sending messages!", exception);
+		this.captcha = captcha;
 	}
 }

--- a/library/src/main/java/com/pokegoapi/exceptions/AsyncCaptchaActiveException.java
+++ b/library/src/main/java/com/pokegoapi/exceptions/AsyncCaptchaActiveException.java
@@ -13,21 +13,17 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.pokegoapi.auth;
-
-import POGOProtos.Networking.Envelopes.RequestEnvelopeOuterClass.RequestEnvelope.AuthInfo;
-import com.pokegoapi.exceptions.CaptchaActiveException;
-import com.pokegoapi.exceptions.LoginFailedException;
-import com.pokegoapi.exceptions.RemoteServerException;
+package com.pokegoapi.exceptions;
 
 /**
- * Any Credential Provider can extend this.
+ * Exception thrown when a message is requested to send, but a captcha is currently active
  */
-public abstract class CredentialProvider {
+public class AsyncCaptchaActiveException extends AsyncPokemonGoException {
+	public AsyncCaptchaActiveException() {
+		super("Captcha must be solved before sending messages!");
+	}
 
-	public abstract String getTokenId() throws LoginFailedException, CaptchaActiveException, RemoteServerException;
-
-	public abstract AuthInfo getAuthInfo() throws LoginFailedException, CaptchaActiveException, RemoteServerException;
-
-	public abstract boolean isTokenIdExpired();
+	public AsyncCaptchaActiveException(Exception exception) {
+		super("Captcha must be solved before sending messages!", exception);
+	}
 }

--- a/library/src/main/java/com/pokegoapi/exceptions/CaptchaActiveException.java
+++ b/library/src/main/java/com/pokegoapi/exceptions/CaptchaActiveException.java
@@ -13,21 +13,17 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.pokegoapi.auth;
-
-import POGOProtos.Networking.Envelopes.RequestEnvelopeOuterClass.RequestEnvelope.AuthInfo;
-import com.pokegoapi.exceptions.CaptchaActiveException;
-import com.pokegoapi.exceptions.LoginFailedException;
-import com.pokegoapi.exceptions.RemoteServerException;
+package com.pokegoapi.exceptions;
 
 /**
- * Any Credential Provider can extend this.
+ * Exception thrown when a message is requested to send, but a captcha is currently active
  */
-public abstract class CredentialProvider {
+public class CaptchaActiveException extends Exception {
+	public CaptchaActiveException() {
+		super();
+	}
 
-	public abstract String getTokenId() throws LoginFailedException, CaptchaActiveException, RemoteServerException;
-
-	public abstract AuthInfo getAuthInfo() throws LoginFailedException, CaptchaActiveException, RemoteServerException;
-
-	public abstract boolean isTokenIdExpired();
+	public CaptchaActiveException(Throwable exception) {
+		super(exception);
+	}
 }

--- a/library/src/main/java/com/pokegoapi/exceptions/CaptchaActiveException.java
+++ b/library/src/main/java/com/pokegoapi/exceptions/CaptchaActiveException.java
@@ -15,15 +15,14 @@
 
 package com.pokegoapi.exceptions;
 
-/**
- * Exception thrown when a message is requested to send, but a captcha is currently active
- */
-public class CaptchaActiveException extends Exception {
-	public CaptchaActiveException() {
-		super();
-	}
+import lombok.Getter;
 
-	public CaptchaActiveException(Throwable exception) {
-		super(exception);
+public class CaptchaActiveException extends Exception {
+	@Getter
+	private String captcha;
+
+	public CaptchaActiveException(AsyncCaptchaActiveException exception) {
+		super(exception.getMessage(), exception);
+		this.captcha = exception.getCaptcha();
 	}
 }

--- a/library/src/main/java/com/pokegoapi/main/CommonRequests.java
+++ b/library/src/main/java/com/pokegoapi/main/CommonRequests.java
@@ -161,6 +161,7 @@ public class CommonRequests {
 	/**
 	 * Append CheckChallenge request to the given ServerRequest
 	 *
+	 * @param api the current api instance
 	 * @param requests The main requests we want to fire
 	 * @return an array of ServerRequests
 	 */

--- a/library/src/main/java/com/pokegoapi/main/RequestHandler.java
+++ b/library/src/main/java/com/pokegoapi/main/RequestHandler.java
@@ -18,10 +18,12 @@ package com.pokegoapi.main;
 import POGOProtos.Networking.Envelopes.AuthTicketOuterClass.AuthTicket;
 import POGOProtos.Networking.Envelopes.RequestEnvelopeOuterClass.RequestEnvelope;
 import POGOProtos.Networking.Envelopes.ResponseEnvelopeOuterClass.ResponseEnvelope;
+import POGOProtos.Networking.Requests.RequestTypeOuterClass;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.exceptions.AsyncPokemonGoException;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.AsyncHelper;
@@ -64,7 +66,7 @@ public class RequestHandler implements Runnable {
 	/**
 	 * Instantiates a new Request handler.
 	 *
-	 * @param api    the api
+	 * @param api the api
 	 * @param client the client
 	 */
 	public RequestHandler(PokemonGo api, OkHttpClient client) {
@@ -145,9 +147,11 @@ public class RequestHandler implements Runnable {
 	 *
 	 * @param serverRequests list of ServerRequests to be sent
 	 * @throws RemoteServerException the remote server exception
-	 * @throws LoginFailedException  the login failed exception
+	 * @throws LoginFailedException the login failed exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
-	public void sendServerRequests(ServerRequest... serverRequests) throws RemoteServerException, LoginFailedException {
+	public void sendServerRequests(ServerRequest... serverRequests)
+			throws RemoteServerException, LoginFailedException, CaptchaActiveException {
 		List<Observable<ByteString>> observables = new ArrayList<>(serverRequests.length);
 		for (ServerRequest request : serverRequests) {
 			AsyncServerRequest asyncServerRequest = new AsyncServerRequest(request.getType(), request.getRequest());
@@ -163,10 +167,11 @@ public class RequestHandler implements Runnable {
 	 *
 	 * @param serverRequests list of ServerRequests to be sent
 	 * @throws RemoteServerException the remote server exception
-	 * @throws LoginFailedException  the login failed exception
+	 * @throws LoginFailedException the login failed exception
+	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
 	 */
 	private AuthTicket internalSendServerRequests(AuthTicket authTicket, ServerRequest... serverRequests)
-			throws RemoteServerException, LoginFailedException {
+			throws RemoteServerException, CaptchaActiveException, LoginFailedException {
 		AuthTicket newAuthTicket = authTicket;
 		if (serverRequests.length == 0) {
 			return authTicket;
@@ -251,7 +256,7 @@ public class RequestHandler implements Runnable {
 	}
 
 	private void resetBuilder(RequestEnvelope.Builder builder, AuthTicket authTicket)
-			throws LoginFailedException, RemoteServerException {
+			throws LoginFailedException, CaptchaActiveException, RemoteServerException {
 		builder.setStatusCode(2);
 		builder.setRequestId(getRequestId());
 		//builder.setAuthInfo(api.getAuthInfo());
@@ -283,18 +288,32 @@ public class RequestHandler implements Runnable {
 			} catch (InterruptedException e) {
 				throw new AsyncPokemonGoException("System shutdown", e);
 			}
-			if (workQueue.isEmpty() || api.hasChallenge()) {
+			if (workQueue.isEmpty()) {
 				continue;
 			}
 
 			workQueue.drainTo(requests);
 
-			ArrayList<ServerRequest> serverRequests = new ArrayList<>();
 			boolean addCommon = false;
-			for (AsyncServerRequest request : requests) {
-				serverRequests.add(new ServerRequest(request.getType(), request.getRequest()));
-				if (request.isRequireCommonRequest())
-					addCommon = true;
+
+			ArrayList<ServerRequest> serverRequests = new ArrayList<>();
+
+			if (api.hasChallenge()) {
+				for (AsyncServerRequest request : requests) {
+					if (request.getType() == RequestTypeOuterClass.RequestType.CHECK_CHALLENGE
+							|| request.getType() == RequestTypeOuterClass.RequestType.VERIFY_CHALLENGE) {
+						serverRequests.add(new ServerRequest(request.getType(), request.getRequest()));
+					} else {
+						resultMap.put(request.getId(), ResultOrException.getError(new CaptchaActiveException()));
+					}
+				}
+			} else {
+				for (AsyncServerRequest request : requests) {
+					serverRequests.add(new ServerRequest(request.getType(), request.getRequest()));
+					if (request.isRequireCommonRequest()) {
+						addCommon = true;
+					}
+				}
 			}
 
 			ServerRequest[] commonRequests = new ServerRequest[0];
@@ -327,7 +346,7 @@ public class RequestHandler implements Runnable {
 				}
 
 				continue;
-			} catch (RemoteServerException | LoginFailedException e) {
+			} catch (RemoteServerException | LoginFailedException | CaptchaActiveException e) {
 				for (AsyncServerRequest request : requests) {
 					resultMap.put(request.getId(), ResultOrException.getError(e));
 				}

--- a/library/src/main/java/com/pokegoapi/main/RequestHandler.java
+++ b/library/src/main/java/com/pokegoapi/main/RequestHandler.java
@@ -310,7 +310,7 @@ public class RequestHandler implements Runnable {
 						serverRequests.add(serverRequest);
 						requestMap.put(serverRequest, request);
 					} else {
-						resultMap.put(request.getId(), ResultOrException.getError(new AsyncCaptchaActiveException()));
+						resultMap.put(request.getId(), ResultOrException.getError(new AsyncCaptchaActiveException(api.getChallengeURL())));
 					}
 				}
 			} else {

--- a/library/src/main/java/com/pokegoapi/util/AsyncHelper.java
+++ b/library/src/main/java/com/pokegoapi/util/AsyncHelper.java
@@ -15,9 +15,11 @@
 
 package com.pokegoapi.util;
 
+import com.pokegoapi.exceptions.AsyncCaptchaActiveException;
 import com.pokegoapi.exceptions.AsyncLoginFailedException;
 import com.pokegoapi.exceptions.AsyncPokemonGoException;
 import com.pokegoapi.exceptions.AsyncRemoteServerException;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 
@@ -32,8 +34,10 @@ public class AsyncHelper {
 	 * @return Result of the observable
 	 * @throws LoginFailedException  If an AsyncLoginFailedException was thrown
 	 * @throws RemoteServerException If an AsyncRemoteServerException was thrown
+	 * @throws CaptchaActiveException if an AsyncCaptchaActiveException was thrown
 	 */
-	public static <T> T toBlocking(Observable<T> observable) throws LoginFailedException, RemoteServerException {
+	public static <T> T toBlocking(Observable<T> observable)
+			throws LoginFailedException, RemoteServerException, CaptchaActiveException {
 		try {
 			return observable.toBlocking().first();
 		} catch (RuntimeException e) {
@@ -43,28 +47,8 @@ public class AsyncHelper {
 			if (e.getCause() instanceof AsyncRemoteServerException) {
 				throw new RemoteServerException(e.getMessage(), e.getCause());
 			}
-			throw new AsyncPokemonGoException("Unknown exception occurred. ", e);
-		}
-	}
-
-	/**
-	 * Convert an observable to the actual result, recovering the actual exception and throwing that
-	 *
-	 * @param observable Observable to handle
-	 * @param <T>        Result type
-	 * @return Result of the observable
-	 * @throws LoginFailedException  If an AsyncLoginFailedException was thrown
-	 * @throws RemoteServerException If an AsyncRemoteServerException was thrown
-	 */
-	public static <T> T toCompose(Observable<T> observable) throws LoginFailedException, RemoteServerException {
-		try {
-			return observable.toBlocking().first();
-		} catch (RuntimeException e) {
-			if (e.getCause() instanceof AsyncLoginFailedException) {
-				throw new LoginFailedException(e.getMessage(), e.getCause());
-			}
-			if (e.getCause() instanceof AsyncRemoteServerException) {
-				throw new RemoteServerException(e.getMessage(), e.getCause());
+			if (e.getCause() instanceof AsyncCaptchaActiveException) {
+				throw new CaptchaActiveException(e.getCause());
 			}
 			throw new AsyncPokemonGoException("Unknown exception occurred. ", e);
 		}

--- a/library/src/main/java/com/pokegoapi/util/AsyncHelper.java
+++ b/library/src/main/java/com/pokegoapi/util/AsyncHelper.java
@@ -48,7 +48,7 @@ public class AsyncHelper {
 				throw new RemoteServerException(e.getMessage(), e.getCause());
 			}
 			if (e.getCause() instanceof AsyncCaptchaActiveException) {
-				throw new CaptchaActiveException(e.getCause());
+				throw new CaptchaActiveException((AsyncCaptchaActiveException) e.getCause());
 			}
 			throw new AsyncPokemonGoException("Unknown exception occurred. ", e);
 		}

--- a/library/src/main/java/com/pokegoapi/util/Crypto.java
+++ b/library/src/main/java/com/pokegoapi/util/Crypto.java
@@ -50,7 +50,7 @@ public class Crypto {
 	 * Shuffles bytes.
 	 *
 	 * @param input input data
-	 * @param msSinceStart
+	 * @param msSinceStart time since start
 	 * @return shuffled bytes
 	 */
 	public static CipherText encrypt(byte[] input, long msSinceStart) {
@@ -3519,7 +3519,7 @@ public class Crypto {
 		 * Create new CipherText with contents and IV.
 		 *
 		 * @param input the contents
-		 * @param ms
+		 * @param ms the time
 		 */
 		public CipherText(byte[] input, long ms, Rand rand) {
 			this.inputLen = input.length;

--- a/sample/src/main/java/com/pokegoapi/examples/CatchPokemonAtAreaExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/CatchPokemonAtAreaExample.java
@@ -39,6 +39,7 @@ import com.pokegoapi.api.map.pokemon.encounter.EncounterResult;
 import com.pokegoapi.api.settings.CatchOptions;
 import com.pokegoapi.api.settings.PokeballSelector;
 import com.pokegoapi.auth.PtcCredentialProvider;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.NoSuchItemException;
 import com.pokegoapi.exceptions.RemoteServerException;
@@ -90,9 +91,9 @@ public class CatchPokemonAtAreaExample {
 
 			}
 
-		} catch (LoginFailedException | NoSuchItemException | RemoteServerException e) {
+		} catch (LoginFailedException | NoSuchItemException | RemoteServerException | CaptchaActiveException e) {
 			// failed to login, invalid credentials, auth issue or server issue.
-			Log.e("Main", "Failed to login or server issue: ", e);
+			Log.e("Main", "Failed to login, captcha or server issue: ", e);
 
 		}
 	}

--- a/sample/src/main/java/com/pokegoapi/examples/FightGymExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/FightGymExample.java
@@ -38,6 +38,7 @@ import com.pokegoapi.api.gym.Gym;
 import com.pokegoapi.api.pokemon.Pokemon;
 import com.pokegoapi.auth.CredentialProvider;
 import com.pokegoapi.auth.PtcCredentialProvider;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.Log;
@@ -94,9 +95,9 @@ public class FightGymExample {
 
 			}
 
-		} catch (LoginFailedException | RemoteServerException | InterruptedException e) {
+		} catch (LoginFailedException | RemoteServerException | InterruptedException | CaptchaActiveException e) {
 			// failed to login, invalid credentials, auth issue or server issue.
-			Log.e("Main", "Failed to login or server issue: ", e);
+			Log.e("Main", "Failed to login, captcha or server issue: ", e);
 
 		}
 	}

--- a/sample/src/main/java/com/pokegoapi/examples/GoogleUserInteractionExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/GoogleUserInteractionExample.java
@@ -17,6 +17,7 @@ package com.pokegoapi.examples;
 
 
 import com.pokegoapi.auth.GoogleUserCredentialProvider;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import okhttp3.OkHttpClient;
@@ -47,7 +48,7 @@ public class GoogleUserInteractionExample {
 			provider.login(access);
 			System.out.println("Refresh token:" + provider.getRefreshToken());
 			
-		} catch (LoginFailedException | RemoteServerException e) {
+		} catch (LoginFailedException | RemoteServerException | CaptchaActiveException e) {
 			e.printStackTrace();
 		}
 

--- a/sample/src/main/java/com/pokegoapi/examples/SolveCaptchaExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/SolveCaptchaExample.java
@@ -42,6 +42,9 @@ import javafx.scene.web.WebView;
 import okhttp3.OkHttpClient;
 
 import javax.swing.JFrame;
+import javax.swing.WindowConstants;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 public class SolveCaptchaExample {
 	/**
@@ -94,6 +97,8 @@ public class SolveCaptchaExample {
 				try {
 					//Close this window, it not valid anymore.
 					frame.setVisible(false);
+					frame.dispose();
+
 					if (api.verifyChallenge(token)) {
 						System.out.println("Captcha was correctly solved!");
 					} else {
@@ -118,5 +123,13 @@ public class SolveCaptchaExample {
 		frame.getContentPane().add(panel);
 		frame.setSize(500, 500);
 		frame.setVisible(true);
+		//Don't allow this window to be closed
+		frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+		frame.addWindowListener(new WindowAdapter() {
+			@Override
+			public void windowClosing(WindowEvent e) {
+				System.out.println("Please solve the captcha before closing the window!");
+			}
+		});
 	}
 }

--- a/sample/src/main/java/com/pokegoapi/examples/SolveCaptchaExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/SolveCaptchaExample.java
@@ -35,6 +35,8 @@ import com.pokegoapi.api.listener.LoginListener;
 import com.pokegoapi.auth.PtcCredentialProvider;
 import com.pokegoapi.util.CaptchaSolveHelper;
 import com.pokegoapi.util.Log;
+import com.sun.javafx.application.PlatformImpl;
+import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.Scene;
 import javafx.scene.web.WebEngine;
@@ -42,6 +44,7 @@ import javafx.scene.web.WebView;
 import okhttp3.OkHttpClient;
 
 import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -56,9 +59,6 @@ public class SolveCaptchaExample {
 		OkHttpClient http = new OkHttpClient();
 		PokemonGo api = new PokemonGo(http);
 		try {
-			api.login(new PtcCredentialProvider(http, ExampleLoginDetails.LOGIN, ExampleLoginDetails.PASSWORD));
-			api.setLocation(-32.058087, 115.744325, 0);
-
 			//Add listener to listen for the captcha URL
 			api.addListener(new LoginListener() {
 				@Override
@@ -73,62 +73,86 @@ public class SolveCaptchaExample {
 				}
 			});
 
+			api.login(new PtcCredentialProvider(http, ExampleLoginDetails.LOGIN, ExampleLoginDetails.PASSWORD));
+//			api.setLocation(-32.058087, 115.744325, 0);
+			api.setLocation(51.507340, -0.127760, 0);
+
+			while (!api.hasChallenge()) {
+			}
 		} catch (Exception e) {
 			Log.e("Main", "Failed to run captcha example! ", e);
 		}
 	}
 
 	private static void completeCaptcha(final PokemonGo api, final String challengeURL) {
-		JFXPanel panel = new JFXPanel();
-		//Create a WebView and WebEngine to display the captcha from challengeURL.
-		WebView view = new WebView();
-		WebEngine engine = view.getEngine();
-		//Set UserAgent so the captcha shows correctly in the WebView.
-		engine.setUserAgent(CaptchaSolveHelper.USER_AGENT);
-		engine.load(challengeURL);
-		final JFrame frame = new JFrame("Solve Captcha");
-		//Register listener to receive the token when the captcha has been solved from inside the WebView.
-		CaptchaSolveHelper.Listener listener = new CaptchaSolveHelper.Listener() {
+		//Run this on the swing thread
+		SwingUtilities.invokeLater(new Runnable() {
 			@Override
-			public void onTokenReceived(String token) {
-				System.out.println("Token received: " + token + "!");
-				//Remove this listener as we no longer need to listen for tokens, the captcha has been solved.
-				CaptchaSolveHelper.removeListener(this);
-				try {
-					//Close this window, it not valid anymore.
-					frame.setVisible(false);
-					frame.dispose();
+			public void run() {
+				//Startup JFX
+				PlatformImpl.startup(new Runnable() {
+					@Override
+					public void run() {
+					}
+				});
 
-					if (api.verifyChallenge(token)) {
-						System.out.println("Captcha was correctly solved!");
-					} else {
-						System.out.println("Captcha was incorrectly solved! Please try again.");
+				//Run on JFX Thread
+				Platform.runLater(new Runnable() {
+					@Override
+					public void run() {
+						JFXPanel panel = new JFXPanel();
+						//Create a WebView and WebEngine to display the captcha from challengeURL.
+						WebView view = new WebView();
+						WebEngine engine = view.getEngine();
+						//Set UserAgent so the captcha shows correctly in the WebView.
+						engine.setUserAgent(CaptchaSolveHelper.USER_AGENT);
+						engine.load(challengeURL);
+						final JFrame frame = new JFrame("Solve Captcha");
+						//Register listener to receive the token when the captcha has been solved from inside the WebView.
+						CaptchaSolveHelper.Listener listener = new CaptchaSolveHelper.Listener() {
+							@Override
+							public void onTokenReceived(String token) {
+								System.out.println("Token received: " + token + "!");
+								//Remove this listener as we no longer need to listen for tokens, the captcha has been solved.
+								CaptchaSolveHelper.removeListener(this);
+								try {
+									//Close this window, it not valid anymore.
+									frame.setVisible(false);
+									frame.dispose();
+
+									if (api.verifyChallenge(token)) {
+										System.out.println("Captcha was correctly solved!");
+									} else {
+										System.out.println("Captcha was incorrectly solved! Please try again.");
 
 						/*
 							Ask for a new challenge url, don't need to check the result,
 							because the LoginListener will be called when this completed.
 						*/
+										api.checkChallenge();
+									}
+								} catch (Exception e) {
+									Log.e("Main", "Error while solving captcha!", e);
+								}
+							}
+						};
+						CaptchaSolveHelper.registerListener(listener);
 
-						api.checkChallenge();
+						//Applies the WebView to this panel
+						panel.setScene(new Scene(view));
+						frame.getContentPane().add(panel);
+						frame.setSize(500, 500);
+						frame.setVisible(true);
+						//Don't allow this window to be closed
+						frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+						frame.addWindowListener(new WindowAdapter() {
+							@Override
+							public void windowClosing(WindowEvent e) {
+								System.out.println("Please solve the captcha before closing the window!");
+							}
+						});
 					}
-				} catch (Exception e) {
-					Log.e("Main", "Error while solving captcha!", e);
-				}
-			}
-		};
-		CaptchaSolveHelper.registerListener(listener);
-
-		//Applies the WebView to this panel
-		panel.setScene(new Scene(view));
-		frame.getContentPane().add(panel);
-		frame.setSize(500, 500);
-		frame.setVisible(true);
-		//Don't allow this window to be closed
-		frame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-		frame.addWindowListener(new WindowAdapter() {
-			@Override
-			public void windowClosing(WindowEvent e) {
-				System.out.println("Please solve the captcha before closing the window!");
+				});
 			}
 		});
 	}

--- a/sample/src/main/java/com/pokegoapi/examples/TransferOnePidgeyExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/TransferOnePidgeyExample.java
@@ -20,6 +20,7 @@ import POGOProtos.Networking.Responses.ReleasePokemonResponseOuterClass;
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.pokemon.Pokemon;
 import com.pokegoapi.auth.PtcCredentialProvider;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.Log;
@@ -53,9 +54,9 @@ public class TransferOnePidgeyExample {
 			} else {
 				Log.i("Main", "You have no pidgeys :O");
 			}
-		} catch (LoginFailedException | RemoteServerException e) {
+		} catch (LoginFailedException | RemoteServerException | CaptchaActiveException e) {
 			// failed to login, invalid credentials, auth issue or server issue.
-			Log.e("Main", "Failed to login. Invalid credentials or server issue: ", e);
+			Log.e("Main", "Failed to login. Invalid credentials, captcha or server issue: ", e);
 		}
 	}
 }

--- a/sample/src/main/java/com/pokegoapi/examples/TutorialHandleExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/TutorialHandleExample.java
@@ -37,6 +37,7 @@ import com.pokegoapi.api.player.Avatar;
 import com.pokegoapi.api.player.PlayerAvatar;
 import com.pokegoapi.api.pokemon.StarterPokemon;
 import com.pokegoapi.auth.PtcCredentialProvider;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.Log;
@@ -93,7 +94,7 @@ public class TutorialHandleExample {
 				}
 			});
 			api.login(provider);
-		} catch (LoginFailedException | RemoteServerException e) {
+		} catch (LoginFailedException | RemoteServerException | CaptchaActiveException e) {
 			Log.e("Main", "Failed to login!", e);
 		}
 	}

--- a/sample/src/main/java/com/pokegoapi/examples/UseIncenseExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/UseIncenseExample.java
@@ -33,6 +33,7 @@ package com.pokegoapi.examples;
 
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.auth.GoogleAutoCredentialProvider;
+import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.Log;
@@ -59,9 +60,9 @@ public class UseIncenseExample {
 			go.setLocation(45.817521, 16.028199, 0);
 			go.getInventories().getItemBag().useIncense();
 
-		} catch (LoginFailedException | RemoteServerException e) {
+		} catch (LoginFailedException | RemoteServerException | CaptchaActiveException e) {
 			// failed to login, invalid credentials, auth issue or server issue.
-			Log.e("Main", "Failed to login or server issue: ", e);
+			Log.e("Main", "Failed to login, captcha or server issue: ", e);
 
 		}
 	}


### PR DESCRIPTION
This PR adds a new exception, CaptchaActiveException, throwable from all messages sent to the server.
This will prevent any messages being sent (requesting more captchas from the common request) while the captcha is active, as the app does.

This PR also fixes the parsing of common requests and duplication of incubators, Previously, common requests were only parsed if the 'addCommonRequests' flag was set on the server request.