### PR TITLE
Support for PokeHash hasher

### DIFF
--- a/library/src/main/java/com/pokegoapi/api/inventory/Inventories.java
+++ b/library/src/main/java/com/pokegoapi/api/inventory/Inventories.java
@@ -15,11 +15,13 @@
 
 package com.pokegoapi.api.inventory;
 
+import POGOProtos.Data.PokemonDataOuterClass.PokemonData;
 import POGOProtos.Enums.PokemonFamilyIdOuterClass;
 import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
 import POGOProtos.Inventory.AppliedItemOuterClass.AppliedItem;
 import POGOProtos.Inventory.AppliedItemsOuterClass.AppliedItems;
 import POGOProtos.Inventory.EggIncubatorOuterClass;
+import POGOProtos.Inventory.EggIncubatorsOuterClass.EggIncubators;
 import POGOProtos.Inventory.InventoryItemDataOuterClass;
 import POGOProtos.Inventory.InventoryItemOuterClass;
 import POGOProtos.Inventory.Item.ItemDataOuterClass.ItemData;
@@ -146,12 +148,13 @@ public class Inventories {
 			InventoryItemDataOuterClass.InventoryItemData itemData = inventoryItem.getInventoryItemData();
 
 			// hatchery
-			if (itemData.getPokemonData().getPokemonId() == PokemonId.MISSINGNO && itemData.getPokemonData().getIsEgg()) {
-				hatchery.addEgg(new EggPokemon(itemData.getPokemonData()));
+			PokemonData pokemonData = itemData.getPokemonData();
+			if (pokemonData.getPokemonId() == PokemonId.MISSINGNO && pokemonData.getIsEgg()) {
+				hatchery.addEgg(new EggPokemon(pokemonData));
 			}
 
 			// pokebank
-			if (itemData.getPokemonData().getPokemonId() != PokemonId.MISSINGNO) {
+			if (pokemonData.getPokemonId() != PokemonId.MISSINGNO) {
 				pokebank.addPokemon(new Pokemon(api, inventoryItem.getInventoryItemData().getPokemonData()));
 			}
 
@@ -183,7 +186,8 @@ public class Inventories {
 			}
 
 			if (itemData.hasEggIncubators()) {
-				for (EggIncubatorOuterClass.EggIncubator incubator : itemData.getEggIncubators().getEggIncubatorList()) {
+				EggIncubators eggIncubators = itemData.getEggIncubators();
+				for (EggIncubatorOuterClass.EggIncubator incubator : eggIncubators.getEggIncubatorList()) {
 					EggIncubator eggIncubator = new EggIncubator(api, incubator);
 					synchronized (this.lock) {
 						incubators.remove(eggIncubator);

--- a/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
+++ b/library/src/main/java/com/pokegoapi/api/pokemon/Pokemon.java
@@ -185,7 +185,7 @@ public class Pokemon extends PokemonDetails {
 	 *
 	 * @param considerMaxCPLimitForPlayerLevel Consider max cp limit for actual player level
 	 * @return the boolean
-	 * @throws NoSuchItemException   If the PokemonId value cannot be found in the {@link PokemonMetaRegistry}.
+	 * @throws NoSuchItemException   If the PokemonId value cannot be found in the {@link com.pokegoapi.main.PokemonMeta}.
 	 */
 	public boolean canPowerUp(boolean considerMaxCPLimitForPlayerLevel)
 			throws NoSuchItemException {
@@ -463,5 +463,15 @@ public class Pokemon extends PokemonDetails {
 	 */
 	public double getIvInPercentage() {
 		return ((Math.floor((this.getIvRatio() * 100) * 100)) / 100);
+	}
+
+	@Override
+	public int hashCode() {
+		return (int) getId();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return obj instanceof Pokemon && ((Pokemon) obj).getId() == getId();
 	}
 }

--- a/library/src/main/java/com/pokegoapi/exceptions/hash/HashException.java
+++ b/library/src/main/java/com/pokegoapi/exceptions/hash/HashException.java
@@ -13,14 +13,22 @@
  *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.pokegoapi.util;
+package com.pokegoapi.exceptions.hash;
 
-/**
- * Created by iGio90 on 27/08/16.
- */
+public class HashException extends Exception {
+	public HashException() {
+		super();
+	}
 
-public class Constant {
-	public static final int APP_VERSION = 4500;
+	public HashException(String reason) {
+		super(reason);
+	}
 
-	public static final long UNK25 = -1553869577012279119L;
+	public HashException(Throwable exception) {
+		super(exception);
+	}
+
+	public HashException(String reason, Throwable exception) {
+		super(reason, exception);
+	}
 }

--- a/library/src/main/java/com/pokegoapi/exceptions/hash/HashLimitExceededException.java
+++ b/library/src/main/java/com/pokegoapi/exceptions/hash/HashLimitExceededException.java
@@ -1,0 +1,30 @@
+/*
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pokegoapi.exceptions.hash;
+
+public class HashLimitExceededException extends HashException {
+	public HashLimitExceededException() {
+		super();
+	}
+
+	public HashLimitExceededException(String reason) {
+		super(reason);
+	}
+
+	public HashLimitExceededException(Throwable exception) {
+		super(exception);
+	}
+}

--- a/library/src/main/java/com/pokegoapi/main/CommonRequests.java
+++ b/library/src/main/java/com/pokegoapi/main/CommonRequests.java
@@ -39,7 +39,6 @@ import com.pokegoapi.api.listener.PokemonListener;
 import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
-import com.pokegoapi.util.Constant;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -158,25 +157,27 @@ public class CommonRequests {
 	/**
 	 * Constant for repetitive usage of DownloadRemoteConfigVersionMessage request
 	 *
+	 * @param api the current API instance
 	 * @return DownloadRemoteConfigVersionMessage
 	 */
-	public static DownloadRemoteConfigVersionMessage getDownloadRemoteConfigVersionMessageRequest() {
+	public static DownloadRemoteConfigVersionMessage getDownloadRemoteConfigVersionMessageRequest(PokemonGo api) {
 		return DownloadRemoteConfigVersionMessage
 				.newBuilder()
 				.setPlatform(Platform.IOS)
-				.setAppVersion(Constant.APP_VERSION)
+				.setAppVersion(api.getVersion())
 				.build();
 	}
 
 	/**
 	 * Constant for repetitive usage of GetAssetDigestMessage request
 	 *
+	 * @param api the current API instance
 	 * @return GetAssetDigestMessage
 	 */
-	public static GetAssetDigestMessage getGetAssetDigestMessageRequest() {
+	public static GetAssetDigestMessage getGetAssetDigestMessageRequest(PokemonGo api) {
 		return GetAssetDigestMessage.newBuilder()
 				.setPlatform(Platform.IOS)
-				.setAppVersion(Constant.APP_VERSION)
+				.setAppVersion(api.getVersion())
 				.build();
 	}
 

--- a/library/src/main/java/com/pokegoapi/main/RequestHandler.java
+++ b/library/src/main/java/com/pokegoapi/main/RequestHandler.java
@@ -28,6 +28,7 @@ import com.pokegoapi.exceptions.AsyncPokemonGoException;
 import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
+import com.pokegoapi.exceptions.hash.HashException;
 import com.pokegoapi.util.AsyncHelper;
 import com.pokegoapi.util.Log;
 import com.pokegoapi.util.Signature;
@@ -177,9 +178,10 @@ public class RequestHandler implements Runnable {
 	 * @throws RemoteServerException the remote server exception
 	 * @throws LoginFailedException the login failed exception
 	 * @throws CaptchaActiveException if a captcha is active and the message can't be sent
+	 * @throws HashException if hashing fails
 	 */
 	private AuthTicket internalSendServerRequests(AuthTicket authTicket, ServerRequest... serverRequests)
-			throws RemoteServerException, CaptchaActiveException, LoginFailedException {
+			throws RemoteServerException, CaptchaActiveException, LoginFailedException, HashException {
 		AuthTicket newAuthTicket = authTicket;
 		if (serverRequests.length == 0) {
 			return authTicket;
@@ -384,7 +386,7 @@ public class RequestHandler implements Runnable {
 					continue;
 				}
 				continue;
-			} catch (RemoteServerException | LoginFailedException | CaptchaActiveException e) {
+			} catch (RemoteServerException | LoginFailedException | CaptchaActiveException | HashException e) {
 				for (AsyncServerRequest request : requests) {
 					resultMap.put(request.getId(), ResultOrException.getError(e));
 				}

--- a/library/src/main/java/com/pokegoapi/util/Signature.java
+++ b/library/src/main/java/com/pokegoapi/util/Signature.java
@@ -48,7 +48,6 @@ public class Signature {
 			return;
 		}
 
-		HashProvider provider = api.getHashProvider();
 
 		byte[] authTicket = builder.getAuthTicket().toByteArray();
 
@@ -56,8 +55,6 @@ public class Signature {
 			return;
 		}
 
-		long currentTime = api.currentTimeMillis();
-		long timeSinceStart = currentTime - api.getStartTime();
 
 		byte[][] requestData = new byte[builder.getRequestsCount()][];
 		for (int i = 0; i < builder.getRequestsCount(); i++) {
@@ -78,10 +75,13 @@ public class Signature {
 			accuracy = 0.0;
 		}
 
+		long currentTime = api.currentTimeMillis();
 		byte[] sessionHash = api.getSessionHash();
+		HashProvider provider = api.getHashProvider();
 		Hash hash = provider.provide(currentTime, latitude, longitude, accuracy, authTicket, sessionHash, requestData);
 		Crypto crypto = provider.getCrypto();
 
+		long timeSinceStart = currentTime - api.getStartTime();
 		SignatureOuterClass.Signature.Builder signatureBuilder = SignatureOuterClass.Signature.newBuilder()
 				.setLocationHash1(hash.getLocationAuthHash())
 				.setLocationHash2(hash.getLocationHash())

--- a/library/src/main/java/com/pokegoapi/util/hash/Hash.java
+++ b/library/src/main/java/com/pokegoapi/util/hash/Hash.java
@@ -27,6 +27,12 @@ public class Hash {
 	@Getter
 	private final List<Long> requestHashes;
 
+	/**
+	 * Creates a hash object
+	 * @param locationAuthHash the hash of the location & auth ticket
+	 * @param locationHash the hash of the location
+	 * @param requestHashes the hash of each request
+	 */
 	public Hash(int locationAuthHash, int locationHash, List<Long> requestHashes) {
 		this.locationAuthHash = locationAuthHash;
 		this.locationHash = locationHash;

--- a/library/src/main/java/com/pokegoapi/util/hash/Hash.java
+++ b/library/src/main/java/com/pokegoapi/util/hash/Hash.java
@@ -1,0 +1,35 @@
+/*
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pokegoapi.util.hash;
+
+import lombok.Getter;
+
+import java.util.List;
+
+public class Hash {
+	@Getter
+	private final int locationAuthHash;
+	@Getter
+	private final int locationHash;
+	@Getter
+	private final List<Long> requestHashes;
+
+	public Hash(int locationAuthHash, int locationHash, List<Long> requestHashes) {
+		this.locationAuthHash = locationAuthHash;
+		this.locationHash = locationHash;
+		this.requestHashes = requestHashes;
+	}
+}

--- a/library/src/main/java/com/pokegoapi/util/hash/HashProvider.java
+++ b/library/src/main/java/com/pokegoapi/util/hash/HashProvider.java
@@ -1,0 +1,53 @@
+/*
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pokegoapi.util.hash;
+
+import com.pokegoapi.exceptions.hash.HashException;
+import com.pokegoapi.util.hash.crypto.Crypto;
+
+public interface HashProvider {
+	/**
+	 * Provides a hash for the given input
+	 *
+	 * @param timestamp timestamp to hash
+	 * @param latitude latitude to hash
+	 * @param longitude longitude to hash
+	 * @param altitude altitude to hash
+	 * @param authTicket auth ticket to hash
+	 * @param sessionData session data to hash
+	 * @param requests request data to hash
+	 * @return the hash for the given input
+	 * @throws HashException if an exception occurs while hashing the given inputs
+	 */
+	Hash provide(long timestamp, double latitude, double longitude, double altitude,
+					byte[] authTicket, byte[] sessionData, byte[][] requests)
+			throws HashException;
+
+	/**
+	 * @return the version this hash supports, for example 4500 = 0.45.0 and 5100 = 0.51.0
+	 */
+	int getHashVersion();
+
+	/**
+	 * @return the instance of crypto this hash should use
+	 */
+	Crypto getCrypto();
+
+	/**
+	 * @return the unknown 25 value used with this hash
+	 */
+	long getUNK25();
+}

--- a/library/src/main/java/com/pokegoapi/util/hash/crypto/Crypto.java
+++ b/library/src/main/java/com/pokegoapi/util/hash/crypto/Crypto.java
@@ -1,0 +1,150 @@
+/*
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pokegoapi.util.hash.crypto;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class Crypto {
+	public static final Crypto LEGACY = new Crypto();
+
+	protected static class Rand {
+		public long state;
+	}
+
+	protected byte[] makeIv(Rand rand) {
+		byte[] iv = new byte[256];
+		for (int i = 0; i < 256; i++) {
+			rand.state = (0x41C64E6D * rand.state) + 0x3039;
+			long shiftedRand = rand.state >> 16;
+			iv[i] = Long.valueOf(shiftedRand).byteValue();
+		}
+		return iv;
+	}
+
+	protected byte makeIntegrityByte(Rand rand) {
+		rand.state = (0x41C64E6D * rand.state) + 0x3039;
+		long shiftedRand = rand.state >> 16;
+		byte lastbyte = Long.valueOf(shiftedRand).byteValue();
+
+		byte v74 = (byte) ((lastbyte ^ 0x0C) & lastbyte);
+		byte v75 = (byte) (((~v74 & 0x67) | (v74 & 0x98)) ^ 0x6F | (v74 & 8));
+		return v75;
+	}
+
+	/**
+	 * Shuffles bytes.
+	 *
+	 * @param crypto the crypto instance to use
+	 * @param input input data
+	 * @param msSinceStart time since start
+	 * @return shuffled bytes
+	 */
+	public CipherText encrypt(byte[] input, long msSinceStart) {
+		Rand rand = new Rand();
+
+		byte[] arr3;
+		CipherText output;
+
+		rand.state = msSinceStart;
+
+		byte[] iv = makeIv(rand);
+		output = new CipherText(this, input, msSinceStart, rand);
+
+		for (int i = 0; i < output.content.size(); ++i) {
+			byte[] current = output.content.get(i);
+
+			for (int j = 0; j < 256; j++) {
+				current[j] ^= iv[j];
+			}
+
+			int[] temp2 = new int[0x100 / 4];
+			// only use 256 bytes from input.
+			IntBuffer intBuf = ByteBuffer.wrap(Arrays.copyOf(current, 0x100))//
+					.order(ByteOrder.BIG_ENDIAN)//
+					.asIntBuffer();
+			intBuf.get(temp2);
+			arr3 = Shuffle.shuffle2(temp2);
+
+			System.arraycopy(arr3, 0, iv, 0, 256);
+			System.arraycopy(arr3, 0, current, 0, 256);
+		}
+
+		return output;
+	}
+
+	public static class CipherText {
+		Crypto crypto;
+		Rand rand;
+		byte[] prefix;
+		public ArrayList<byte[]> content;
+
+		int totalsize;
+		int inputLen;
+
+		byte[] intToBytes(long x) {
+			ByteBuffer buffer = ByteBuffer.allocate(4);
+			buffer.putInt(new BigInteger(String.valueOf(x)).intValue());
+			return buffer.array();
+		}
+
+		/**
+		 * Create new CipherText with contents and IV.
+		 *
+		 * @param crypto the crypto instance to use
+		 * @param input the contents
+		 * @param ms the time
+		 */
+		public CipherText(Crypto crypto, byte[] input, long ms, Rand rand) {
+			this.crypto = crypto;
+			this.inputLen = input.length;
+			this.rand = rand;
+			prefix = new byte[32];
+			content = new ArrayList<>();
+			int roundedsize = input.length + (256 - (input.length % 256));
+			for (int i = 0; i < roundedsize / 256; ++i) {
+				content.add(new byte[256]);
+			}
+			totalsize = roundedsize + 5;
+
+			prefix = intToBytes(ms);
+
+			for (int i = 0; i < input.length; ++i)
+				content.get(i / 256)[i % 256] = input[i];
+			byte[] last = content.get(content.size() - 1);
+			last[last.length - 1] = (byte) (256 - (input.length % 256));
+
+		}
+
+		/**
+		 * Convert this Ciptext to a ByteBuffer
+		 *
+		 * @return contents as bytebuffer
+		 */
+		public ByteBuffer toByteBuffer() {
+			ByteBuffer buff = ByteBuffer.allocate(totalsize).put(prefix);
+			for (int i = 0; i < content.size(); ++i)
+				buff.put(content.get(i));
+
+			buff.put(totalsize - 1, crypto.makeIntegrityByte(rand));
+			return buff;
+		}
+	}
+}

--- a/library/src/main/java/com/pokegoapi/util/hash/crypto/Crypto.java
+++ b/library/src/main/java/com/pokegoapi/util/hash/crypto/Crypto.java
@@ -52,7 +52,6 @@ public class Crypto {
 	/**
 	 * Shuffles bytes.
 	 *
-	 * @param crypto the crypto instance to use
 	 * @param input input data
 	 * @param msSinceStart time since start
 	 * @return shuffled bytes
@@ -99,9 +98,9 @@ public class Crypto {
 		int totalsize;
 		int inputLen;
 
-		byte[] intToBytes(long x) {
+		byte[] intBytes(long value) {
 			ByteBuffer buffer = ByteBuffer.allocate(4);
-			buffer.putInt(new BigInteger(String.valueOf(x)).intValue());
+			buffer.putInt(new BigInteger(String.valueOf(value)).intValue());
 			return buffer.array();
 		}
 
@@ -124,7 +123,7 @@ public class Crypto {
 			}
 			totalsize = roundedsize + 5;
 
-			prefix = intToBytes(ms);
+			prefix = intBytes(ms);
 
 			for (int i = 0; i < input.length; ++i)
 				content.get(i / 256)[i % 256] = input[i];

--- a/library/src/main/java/com/pokegoapi/util/hash/crypto/PokeHashCrypto.java
+++ b/library/src/main/java/com/pokegoapi/util/hash/crypto/PokeHashCrypto.java
@@ -20,7 +20,7 @@ public class PokeHashCrypto extends Crypto {
 
 	@Override
 	protected byte makeIntegrityByte(Rand rand) {
-		byte b = Long.valueOf(rand.state >> 16).byteValue();
-		return (byte) (b & 0xE3 | 0x10);
+		byte randState = Long.valueOf(rand.state >> 16).byteValue();
+		return (byte) (randState & 0xE3 | 0x10);
 	}
 }

--- a/library/src/main/java/com/pokegoapi/util/hash/crypto/PokeHashCrypto.java
+++ b/library/src/main/java/com/pokegoapi/util/hash/crypto/PokeHashCrypto.java
@@ -1,0 +1,26 @@
+/*
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pokegoapi.util.hash.crypto;
+
+public class PokeHashCrypto extends Crypto {
+	public static final Crypto POKE_HASH = new PokeHashCrypto();
+
+	@Override
+	protected byte makeIntegrityByte(Rand rand) {
+		byte b = Long.valueOf(rand.state >> 16).byteValue();
+		return (byte) (b & 0xE3 | 0x10);
+	}
+}

--- a/library/src/main/java/com/pokegoapi/util/hash/crypto/Shuffle.java
+++ b/library/src/main/java/com/pokegoapi/util/hash/crypto/Shuffle.java
@@ -1,18 +1,3 @@
-/*
- *     This program is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     This program is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 package com.pokegoapi.util.hash.crypto;
 
 import java.nio.ByteBuffer;
@@ -3427,10 +3412,10 @@ public final class Shuffle {
 		vector[62] = ~(tmp[61] ^ (tmp[181] ^ tmp[119] & tmp[134]));
 		vector[63] = tmp[30];
 
-		ByteBuffer byteBuf_out = ByteBuffer.allocate(0x100).order(ByteOrder.BIG_ENDIAN);
-		IntBuffer intBuf_out = byteBuf_out.asIntBuffer();
-		intBuf_out.put(vector);
+		ByteBuffer byteBufOut = ByteBuffer.allocate(0x100).order(ByteOrder.BIG_ENDIAN);
+		IntBuffer intBufOut = byteBufOut.asIntBuffer();
+		intBufOut.put(vector);
 
-		return byteBuf_out.array();
+		return byteBufOut.array();
 	}
 }

--- a/library/src/main/java/com/pokegoapi/util/hash/legacy/LegacyHashProvider.java
+++ b/library/src/main/java/com/pokegoapi/util/hash/legacy/LegacyHashProvider.java
@@ -1,0 +1,97 @@
+/*
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pokegoapi.util.hash.legacy;
+
+import com.pokegoapi.util.NiaHash;
+import com.pokegoapi.util.hash.Hash;
+import com.pokegoapi.util.hash.HashProvider;
+import com.pokegoapi.util.hash.crypto.Crypto;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 0.45.0 local hash provider, no key required
+ */
+public class LegacyHashProvider implements HashProvider {
+	private static final int VERSION = 4500;
+	private static final long UNK25 = -1553869577012279119L;
+
+	@Override
+	public Hash provide(long timestamp, double latitude, double longitude, double altitude, byte[] authTicket,
+						byte[] sessionData, byte[][] requests) {
+		int locationHash = getLocationHash(latitude, longitude, altitude);
+		int locationAuthHash = getLocationAuthHash(latitude, longitude, altitude, authTicket);
+		List<Long> requestHashes = new ArrayList<>();
+		for (byte[] request : requests) {
+			requestHashes.add(getRequestHash(request, authTicket));
+		}
+		return new Hash(locationAuthHash, locationHash, requestHashes);
+	}
+
+	@Override
+	public int getHashVersion() {
+		return VERSION;
+	}
+
+	@Override
+	public Crypto getCrypto() {
+		return Crypto.LEGACY;
+	}
+
+	@Override
+	public long getUNK25() {
+		return UNK25;
+	}
+
+	private int getLocationHash(double latitude, double longitude, double altitude) {
+		byte[] bytes = new byte[24];
+		System.arraycopy(toBytes(latitude), 0, bytes, 0, 8);
+		System.arraycopy(toBytes(longitude), 0, bytes, 8, 8);
+		System.arraycopy(toBytes(altitude), 0, bytes, 16, 8);
+
+		return NiaHash.hash32(bytes);
+	}
+
+	private int getLocationAuthHash(double latitude, double longitude, double altitude, byte[] authTicket) {
+		byte[] bytes = new byte[24];
+		System.arraycopy(toBytes(latitude), 0, bytes, 0, 8);
+		System.arraycopy(toBytes(longitude), 0, bytes, 8, 8);
+		System.arraycopy(toBytes(altitude), 0, bytes, 16, 8);
+		int seed = NiaHash.hash32(authTicket);
+		return NiaHash.hash32Salt(bytes, NiaHash.toBytes(seed));
+	}
+
+	private long getRequestHash(byte[] request, byte[] authTicket) {
+		byte[] seed = ByteBuffer.allocate(8).putLong(NiaHash.hash64(authTicket)).array();
+		return NiaHash.hash64Salt(request, seed);
+	}
+
+	private byte[] toBytes(double input) {
+		long rawDouble = Double.doubleToRawLongBits(input);
+		return new byte[]{
+				(byte) (rawDouble >>> 56),
+				(byte) (rawDouble >>> 48),
+				(byte) (rawDouble >>> 40),
+				(byte) (rawDouble >>> 32),
+				(byte) (rawDouble >>> 24),
+				(byte) (rawDouble >>> 16),
+				(byte) (rawDouble >>> 8),
+				(byte) rawDouble
+		};
+	}
+}

--- a/library/src/main/java/com/pokegoapi/util/hash/pokehash/PokeHashProvider.java
+++ b/library/src/main/java/com/pokegoapi/util/hash/pokehash/PokeHashProvider.java
@@ -1,0 +1,188 @@
+/*
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.pokegoapi.util.hash.pokehash;
+
+import com.pokegoapi.exceptions.hash.HashException;
+import com.pokegoapi.exceptions.hash.HashLimitExceededException;
+import com.pokegoapi.util.hash.Hash;
+import com.pokegoapi.util.hash.HashProvider;
+import com.pokegoapi.util.hash.crypto.Crypto;
+import com.pokegoapi.util.hash.crypto.PokeHashCrypto;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Moshi.Builder;
+import lombok.Getter;
+import net.iharder.Base64;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+
+/**
+ * Hash provider on latest version, using the PokeHash hashing service.
+ * This requires a key and is not free like the legacy provider.
+ */
+public class PokeHashProvider implements HashProvider {
+	private static final String HASH_ENDPOINT = "http://pokehash.buddyauth.com/api/v122/hash";
+
+	private static final int VERSION = 5100;
+	private static final long UNK25 = -8832040574896607694L;
+
+	private static final Moshi MOSHI = new Builder().build();
+
+	private final String key;
+
+	public PokeHashProvider(String key) {
+		this.key = key;
+		if (key == null) {
+			throw new IllegalArgumentException("Key cannot be null!");
+		}
+	}
+
+	@Override
+	public Hash provide(long timestamp, double latitude, double longitude, double altitude, byte[] authTicket,
+						byte[] sessionData, byte[][] requests) throws HashException {
+		Request request = new Request(latitude, longitude, altitude, timestamp, authTicket, sessionData, requests);
+		try {
+			HttpURLConnection connection = (HttpURLConnection) new URL(HASH_ENDPOINT).openConnection();
+			connection.setRequestMethod("POST");
+			connection.setRequestProperty("X-AuthToken", key);
+			connection.setRequestProperty("content-type", "application/json");
+			connection.setDoOutput(true);
+
+			String requestJSON = MOSHI.adapter(Request.class).toJson(request);
+			DataOutputStream out = new DataOutputStream(connection.getOutputStream());
+			out.writeBytes(requestJSON);
+			out.flush();
+			out.close();
+
+			int responseCode = connection.getResponseCode();
+
+			String error = getError(connection);
+
+			switch (responseCode) {
+				case HttpURLConnection.HTTP_OK:
+					BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+					StringBuilder builder = new StringBuilder();
+					String line;
+					while ((line = in.readLine()) != null) {
+						builder.append(line);
+					}
+					in.close();
+					Response response = MOSHI.adapter(Response.class).fromJson(builder.toString());
+					long locationAuth = response.getLocationAuthHash();
+					long location = response.getLocationHash();
+					int locationAuthHash = (int) ((locationAuth & 0xFFFFFFFFL) ^ (locationAuth >>> 32));
+					int locationHash = (int) ((location & 0xFFFFFFFFL) ^ (location >>> 32));
+					return new Hash(locationAuthHash, locationHash, response.getRequestHashes());
+				case HttpURLConnection.HTTP_BAD_REQUEST:
+					if (error.length() > 0) {
+						throw new HashException(error);
+					}
+					throw new HashException("Bad hash request!");
+				case HttpURLConnection.HTTP_UNAUTHORIZED:
+					if (error.length() > 0) {
+						throw new HashException(error);
+					}
+					throw new HashException("Unauthorized hash request!");
+				case 429:
+					if (error.length() > 0) {
+						throw new HashLimitExceededException(error);
+					}
+					throw new HashLimitExceededException("Exceeded hash limit!");
+				default:
+					if (error.length() > 0) {
+						throw new HashException(error + " (" + responseCode + ")");
+					}
+					throw new HashException("Received unknown response code! (" + responseCode + ")");
+			}
+		} catch (IOException e) {
+			throw new HashException("Failed to perform PokeHash request", e);
+		}
+	}
+
+	private String getError(HttpURLConnection connection) throws IOException {
+		if (connection.getErrorStream() != null) {
+			BufferedReader error = new BufferedReader(new InputStreamReader(connection.getErrorStream()));
+			StringBuilder builder = new StringBuilder();
+			String line;
+			while ((line = error.readLine()) != null) {
+				builder.append(line);
+			}
+			error.close();
+			return builder.toString();
+		}
+		return "";
+	}
+
+	@Override
+	public int getHashVersion() {
+		return VERSION;
+	}
+
+	@Override
+	public Crypto getCrypto() {
+		return PokeHashCrypto.POKE_HASH;
+	}
+
+	@Override
+	public long getUNK25() {
+		return UNK25;
+	}
+
+	private static class Response {
+		@Getter
+		private long locationAuthHash;
+		@Getter
+		private long locationHash;
+		@Getter
+		private List<Long> requestHashes;
+	}
+
+	private static class Request {
+		@Getter
+		private double latitude;
+		@Getter
+		private double longitude;
+		@Getter
+		private double altitude;
+		@Getter
+		private long timestamp;
+		@Getter
+		private String authTicket;
+		@Getter
+		private String sessionData;
+		@Getter
+		private String[] requests;
+
+		private Request(double latitude, double longitude, double altitude, long timestamp, byte[] authTicket,
+						byte[] sessionData, byte[][] requests) {
+			this.latitude = latitude;
+			this.longitude = longitude;
+			this.altitude = altitude;
+			this.timestamp = timestamp;
+			this.authTicket = Base64.encodeBytes(authTicket);
+			this.sessionData = Base64.encodeBytes(sessionData);
+			this.requests = new String[requests.length];
+			for (int i = 0; i < requests.length; i++) {
+				this.requests[i] = Base64.encodeBytes(requests[i]);
+			}
+		}
+	}
+}

--- a/library/src/main/java/com/pokegoapi/util/hash/pokehash/PokeHashProvider.java
+++ b/library/src/main/java/com/pokegoapi/util/hash/pokehash/PokeHashProvider.java
@@ -48,6 +48,10 @@ public class PokeHashProvider implements HashProvider {
 
 	private final String key;
 
+	/**
+	 * Creates a PokeHashProvider with the given key
+	 * @param key the key for the PokeHash API
+	 */
 	public PokeHashProvider(String key) {
 		this.key = key;
 		if (key == null) {

--- a/sample/src/main/java/com/pokegoapi/examples/CatchPokemonAtAreaExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/CatchPokemonAtAreaExample.java
@@ -53,6 +53,7 @@ import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.Log;
 import com.pokegoapi.util.MapUtil;
 import com.pokegoapi.util.PokeDictionary;
+import com.pokegoapi.util.hash.HashProvider;
 import com.pokegoapi.util.path.Path;
 import okhttp3.OkHttpClient;
 
@@ -75,7 +76,8 @@ public class CatchPokemonAtAreaExample {
 		OkHttpClient http = new OkHttpClient();
 		final PokemonGo api = new PokemonGo(http);
 		try {
-			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD));
+			HashProvider hasher = ExampleConstants.getHashProvider();
+			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD), hasher);
 			api.setLocation(ExampleConstants.LATITUDE, ExampleConstants.LONGITUDE, ExampleConstants.ALTITUDE);
 
 			// Catch all pokemon in the current area

--- a/sample/src/main/java/com/pokegoapi/examples/ExampleConstants.java
+++ b/sample/src/main/java/com/pokegoapi/examples/ExampleConstants.java
@@ -31,7 +31,7 @@ public class ExampleConstants {
 	public static final String POKEHASH_KEY = "";
 
 	/**
-	 * Creates the appropriate hash provider, based on if the POKEHASH_KEY property is sent or not
+	 * Creates the appropriate hash provider, based on if the POKEHASH_KEY property is set or not
 	 * @return a hash provider
 	 */
 	public static HashProvider getHashProvider() {

--- a/sample/src/main/java/com/pokegoapi/examples/ExampleConstants.java
+++ b/sample/src/main/java/com/pokegoapi/examples/ExampleConstants.java
@@ -15,6 +15,10 @@
 
 package com.pokegoapi.examples;
 
+import com.pokegoapi.util.hash.HashProvider;
+import com.pokegoapi.util.hash.legacy.LegacyHashProvider;
+import com.pokegoapi.util.hash.pokehash.PokeHashProvider;
+
 /**
  * Created by court on 19/07/2016.
  */
@@ -24,4 +28,18 @@ public class ExampleConstants {
 	public static final double LATITUDE = -32.058087;
 	public static final double LONGITUDE = 115.744325;
 	public static final double ALTITUDE = 0.0;
+	public static final String POKEHASH_KEY = "";
+
+	/**
+	 * Creates the appropriate hash provider, based on if the POKEHASH_KEY property is sent or not
+	 * @return a hash provider
+	 */
+	public static HashProvider getHashProvider() {
+		boolean hasKey = POKEHASH_KEY != null && POKEHASH_KEY.length() > 0;
+		if (hasKey) {
+			return new PokeHashProvider(POKEHASH_KEY);
+		} else {
+			return new LegacyHashProvider();
+		}
+	}
 }

--- a/sample/src/main/java/com/pokegoapi/examples/FightGymExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/FightGymExample.java
@@ -52,6 +52,7 @@ import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.main.PokemonMeta;
 import com.pokegoapi.util.Log;
 import com.pokegoapi.util.MapUtil;
+import com.pokegoapi.util.hash.HashProvider;
 import com.pokegoapi.util.path.Path;
 import okhttp3.OkHttpClient;
 
@@ -69,7 +70,8 @@ public class FightGymExample {
 		final PokemonGo api = new PokemonGo(http);
 		try {
 			//Login and set location
-			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD));
+			HashProvider hasher = ExampleConstants.getHashProvider();
+			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD), hasher);
 			api.setLocation(ExampleConstants.LATITUDE, ExampleConstants.LONGITUDE, ExampleConstants.ALTITUDE);
 
 			List<Pokemon> pokemons = api.getInventories().getPokebank().getPokemons();

--- a/sample/src/main/java/com/pokegoapi/examples/SolveCaptchaExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/SolveCaptchaExample.java
@@ -35,6 +35,7 @@ import com.pokegoapi.api.listener.LoginListener;
 import com.pokegoapi.auth.PtcCredentialProvider;
 import com.pokegoapi.util.CaptchaSolveHelper;
 import com.pokegoapi.util.Log;
+import com.pokegoapi.util.hash.HashProvider;
 import com.sun.javafx.application.PlatformImpl;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
@@ -87,7 +88,8 @@ public class SolveCaptchaExample {
 				}
 			});
 
-			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD));
+			HashProvider hasher = ExampleConstants.getHashProvider();
+			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD), hasher);
 			api.setLocation(ExampleConstants.LATITUDE, ExampleConstants.LONGITUDE, ExampleConstants.ALTITUDE);
 
 			while (!api.hasChallenge()) {

--- a/sample/src/main/java/com/pokegoapi/examples/TransferMultiplePokemon.java
+++ b/sample/src/main/java/com/pokegoapi/examples/TransferMultiplePokemon.java
@@ -17,7 +17,6 @@ package com.pokegoapi.examples;
 
 import POGOProtos.Enums.PokemonFamilyIdOuterClass.PokemonFamilyId;
 import POGOProtos.Enums.PokemonIdOuterClass.PokemonId;
-import POGOProtos.Networking.Responses.ReleasePokemonResponseOuterClass.ReleasePokemonResponse;
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.inventory.PokeBank;
 import com.pokegoapi.api.pokemon.Pokemon;
@@ -26,6 +25,7 @@ import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.Log;
+import com.pokegoapi.util.hash.HashProvider;
 import okhttp3.OkHttpClient;
 
 import java.util.ArrayList;
@@ -42,7 +42,8 @@ public class TransferMultiplePokemon {
 
 		PokemonGo api = new PokemonGo(http);
 		try {
-			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD));
+			HashProvider hasher = ExampleConstants.getHashProvider();
+			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD), hasher);
 			api.setLocation(ExampleConstants.LATITUDE, ExampleConstants.LONGITUDE, ExampleConstants.ALTITUDE);
 
 			PokeBank pokebank = api.getInventories().getPokebank();

--- a/sample/src/main/java/com/pokegoapi/examples/TransferOnePidgeyExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/TransferOnePidgeyExample.java
@@ -24,6 +24,7 @@ import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.Log;
+import com.pokegoapi.util.hash.HashProvider;
 import okhttp3.OkHttpClient;
 
 import java.util.List;
@@ -37,7 +38,8 @@ public class TransferOnePidgeyExample {
 
 		PokemonGo api = new PokemonGo(http);
 		try {
-			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD));
+			HashProvider hasher = ExampleConstants.getHashProvider();
+			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD), hasher);
 			api.setLocation(ExampleConstants.LATITUDE, ExampleConstants.LONGITUDE, ExampleConstants.ALTITUDE);
 
 			List<Pokemon> pidgeys =

--- a/sample/src/main/java/com/pokegoapi/examples/TravelToPokestopExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/TravelToPokestopExample.java
@@ -40,6 +40,7 @@ import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.Log;
+import com.pokegoapi.util.hash.HashProvider;
 import com.pokegoapi.util.path.Path;
 import okhttp3.OkHttpClient;
 
@@ -56,7 +57,8 @@ public class TravelToPokestopExample {
 		OkHttpClient http = new OkHttpClient();
 		PokemonGo api = new PokemonGo(http);
 		try {
-			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD));
+			HashProvider hasher = ExampleConstants.getHashProvider();
+			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD), hasher);
 			api.setLocation(ExampleConstants.LATITUDE, ExampleConstants.LONGITUDE, ExampleConstants.ALTITUDE);
 
 			Set<Pokestop> pokestops = api.getMap().getMapObjects().getPokestops();

--- a/sample/src/main/java/com/pokegoapi/examples/TutorialHandleExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/TutorialHandleExample.java
@@ -41,6 +41,7 @@ import com.pokegoapi.exceptions.CaptchaActiveException;
 import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.Log;
+import com.pokegoapi.util.hash.HashProvider;
 import okhttp3.OkHttpClient;
 
 public class TutorialHandleExample {
@@ -91,7 +92,8 @@ public class TutorialHandleExample {
 							Avatar.FemaleBackpack.GRAY_BLACK_YELLOW_POKEBALL.id());
 				}
 			});
-			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD));
+			HashProvider hasher = ExampleConstants.getHashProvider();
+			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD), hasher);
 			api.setLocation(ExampleConstants.LATITUDE, ExampleConstants.LONGITUDE, ExampleConstants.ALTITUDE);
 		} catch (LoginFailedException | RemoteServerException | CaptchaActiveException e) {
 			Log.e("Main", "Failed to login!", e);

--- a/sample/src/main/java/com/pokegoapi/examples/UseIncenseExample.java
+++ b/sample/src/main/java/com/pokegoapi/examples/UseIncenseExample.java
@@ -38,6 +38,7 @@ import com.pokegoapi.exceptions.LoginFailedException;
 import com.pokegoapi.exceptions.RemoteServerException;
 import com.pokegoapi.util.Log;
 import com.pokegoapi.util.SystemTimeImpl;
+import com.pokegoapi.util.hash.HashProvider;
 import okhttp3.OkHttpClient;
 
 public class UseIncenseExample {
@@ -50,7 +51,8 @@ public class UseIncenseExample {
 		PokemonGo api = new PokemonGo(http, new SystemTimeImpl());
 
 		try {
-			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD));
+			HashProvider hasher = ExampleConstants.getHashProvider();
+			api.login(new PtcCredentialProvider(http, ExampleConstants.LOGIN, ExampleConstants.PASSWORD), hasher);
 			api.setLocation(ExampleConstants.LATITUDE, ExampleConstants.LONGITUDE, ExampleConstants.ALTITUDE);
 			api.getInventories().getItemBag().useIncense();
 		} catch (LoginFailedException | RemoteServerException | CaptchaActiveException e) {


### PR DESCRIPTION
This PR adds support for the PokeHash hasher, while still leaving the old legacy hasher to be used.

A HashProvider object must now be passed to `PokemonGo#login`, along with the `CredentialProvider`.
Both `LegacyHashProvider` and `PokeHashProvider` are available.