### PR TITLE
Deprecate LegacyHashProvider

### DIFF
--- a/library/src/main/java/com/pokegoapi/util/hash/legacy/LegacyHashProvider.java
+++ b/library/src/main/java/com/pokegoapi/util/hash/legacy/LegacyHashProvider.java
@@ -26,7 +26,10 @@ import java.util.List;
 
 /**
  * 0.45.0 local hash provider, no key required
+ * @deprecated Niantic have disabled use of invalid hashes,
+ * {@link com.pokegoapi.util.hash.pokehash.PokeHashProvider} must be used now
  */
+@Deprecated
 public class LegacyHashProvider implements HashProvider {
 	private static final int VERSION = 4500;
 	private static final long UNK25 = -816976800928766045L;

--- a/library/src/main/java/com/pokegoapi/util/hash/pokehash/PokeHashProvider.java
+++ b/library/src/main/java/com/pokegoapi/util/hash/pokehash/PokeHashProvider.java
@@ -38,6 +38,7 @@ import java.util.List;
 /**
  * Hash provider on latest version, using the PokeHash hashing service.
  * This requires a key and is not free like the legacy provider.
+ * @see <a href="https://hashing.pogodev.org/">https://hashing.pogodev.org/</a>
  */
 public class PokeHashProvider implements HashProvider {
 	private static final String DEFAULT_ENDPOINT = "https://pokehash.buddyauth.com/api/v127_4/hash";


### PR DESCRIPTION
Deprecates the LegacyHashProvider due to its inability to be used anymore