### PR TITLE
Update RPC request headers

### DIFF
--- a/library/src/main/java/com/pokegoapi/main/RequestHandler.java
+++ b/library/src/main/java/com/pokegoapi/main/RequestHandler.java
@@ -38,6 +38,7 @@ import com.pokegoapi.exceptions.request.RequestFailedException;
 import com.pokegoapi.util.AsyncHelper;
 import com.pokegoapi.util.Log;
 import com.pokegoapi.util.Signature;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 import okhttp3.Response;
@@ -56,6 +57,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 public class RequestHandler implements Runnable {
 	private static final String API_ENDPOINT = "https://pgorelease.nianticlabs.com/plfe/rpc";
 	private static final int THROTTLE = 350;
+	private static final MediaType BINARY_MEDIA = MediaType.parse("application/binary");
 	private static final String TAG = RequestHandler.class.getSimpleName();
 	private final PokemonGo api;
 	private final Thread asyncHttpThread;
@@ -206,7 +208,7 @@ public class RequestHandler implements Runnable {
 			Log.wtf(TAG, "Failed to write request to bytearray ouput stream. This should never happen", e);
 		}
 
-		RequestBody body = RequestBody.create(null, stream.toByteArray());
+		RequestBody body = RequestBody.create(BINARY_MEDIA, stream.toByteArray());
 		okhttp3.Request httpRequest = new okhttp3.Request.Builder()
 				.url(apiEndpoint)
 				.post(body)

--- a/library/src/main/java/com/pokegoapi/util/ClientInterceptor.java
+++ b/library/src/main/java/com/pokegoapi/util/ClientInterceptor.java
@@ -15,11 +15,11 @@
 
 package com.pokegoapi.util;
 
-import java.io.IOException;
-
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+
+import java.io.IOException;
 
 /**
  * Created by iGio90 on 29/08/16.
@@ -31,8 +31,8 @@ public class ClientInterceptor implements Interceptor {
 	public Response intercept(Interceptor.Chain chain) throws IOException {
 		Request originalRequest = chain.request();
 		Request requestWithUserAgent = originalRequest.newBuilder()
-				.removeHeader("User-Agent")
-				.addHeader("User-Agent", "Niantic App")
+				.header("User-Agent", "Niantic App")
+				.header("Accept-Encoding", "identity, gzip")
 				.build();
 
 		return chain.proceed(requestWithUserAgent);


### PR DESCRIPTION
This PR updates the RPC request headers to the mimic the headers recently published in the PoGoDev Discord. They are a possible cause of recent shadow bans, although this has not yet been confirmed.

```
POST /plfe/86/rpc HTTP/1.1
Content-Type: application/binary
Host: pgorelease.nianticlabs.com
User-Agent: Niantic App
Content-Length: 993
Accept-Encoding: identity, gzip
```